### PR TITLE
fix: frame and render output settings

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### What was the problem/requirement? (What/Why)
+
+### What was the solution? (How)
+
+### What is the impact of this change?
+
+### How was this change tested?
+
+### Was this change documented?
+
+### Is this a breaking change?

--- a/src/deadline/keyshot_adaptor/KeyShotAdaptor/adaptor.py
+++ b/src/deadline/keyshot_adaptor/KeyShotAdaptor/adaptor.py
@@ -26,11 +26,9 @@ class KeyShotNotRunningError(Exception):
     pass
 
 
-_FIRST_KEYSHOT_ACTIONS = ["scene_file", "output_file_path"]
+_FIRST_KEYSHOT_ACTIONS = ["scene_file", "output_file_path", "output_format"]
 
-_KEYSHOT_RUN_KEYS = {
-    "frame",
-}
+_KEYSHOT_RUN_KEYS = {"frame"}
 
 
 def _check_for_exception(func: Callable) -> Callable:
@@ -420,4 +418,5 @@ class KeyShotAdaptor(Adaptor[AdaptorConfiguration]):
         set to be added to the action queue.
         """
         for name in _FIRST_KEYSHOT_ACTIONS:
-            self._action_queue.enqueue_action(Action(name, {name: self.init_data[name]}))
+            if name in self.init_data:
+                self._action_queue.enqueue_action(Action(name, {name: self.init_data[name]}))

--- a/src/deadline/keyshot_adaptor/KeyShotAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/keyshot_adaptor/KeyShotAdaptor/schemas/init_data.schema.json
@@ -2,8 +2,24 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
-        "scene_file": { "type": "string" },
-        "output_file_path": { "type": "string" }
+        "scene_file": {
+            "type": "string"
+        },
+        "output_file_path": {
+            "type": "string"
+        },
+        "output_format": {
+            "enum": [
+                "RENDER_OUTPUT_PNG",
+                "RENDER_OUTPUT_JPEG",
+                "RENDER_OUTPUT_EXR",
+                "RENDER_OUTPUT_TIFF8",
+                "RENDER_OUTPUT_TIFF32",
+                "RENDER_OUTPUT_PSD8",
+                "RENDER_OUTPUT_PSD16",
+                "RENDER_OUTPUT_PSD32"
+            ]
+        }
     },
     "required": [
         "scene_file"

--- a/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_handler.py
+++ b/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_handler.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os as os
+from pprint import pprint
 from typing import Any, Callable, Dict
 
 try:
@@ -21,11 +22,13 @@ class KeyShotHandler:
         self.action_dict = {
             "scene_file": self.set_scene_file,
             "output_file_path": self.set_output_file_path,
+            "output_format": self.set_output_format,
             "frame": self.set_frame,
             "start_render": self.start_render,
         }
         self.render_kwargs = {}
         self.output_path = ""
+        self.output_format_code = lux.RENDER_OUTPUT_PNG  # Default to PNG
 
     def set_output_file_path(self, data: dict) -> None:
         """
@@ -54,8 +57,32 @@ class KeyShotHandler:
         opts.setAddToQueue(False)
         lux.setAnimationFrame(frame)
         output_path = self.output_path.replace("%d", str(frame))
-        lux.renderImage(path=output_path, opts=opts)
-        print("Finished Rendering %s" % output_path)
+        pprint(f"KeyShot Render Options: {opts}", indent=4)
+        print(f"KeyShot Render Output Format: {self.output_format_code}")
+        lux.renderImage(path=output_path, opts=opts, format=self.output_format_code)
+        print(f"Finished Rendering {output_path}")
+
+    def set_output_format(self, data: dict) -> None:
+        """
+        Sets the output format for the render
+
+        Args:
+            data (dict):
+
+        Raises:
+            RuntimeError: If the output format does not exist for KeyShot or if
+                          called without an output_format set
+        """
+        if "output_format" in data:
+            output_format = data["output_format"]
+            try:
+                self.output_format_code = getattr(lux, output_format)
+            except AttributeError:
+                raise RuntimeError(
+                    f"The output format {output_format} is not valid. Valid formats are defined in the init data schema file."
+                )
+        else:
+            raise RuntimeError("set_output_format called without an output_format specified.")
 
     def set_frame(self, data: dict) -> None:
         """

--- a/src/deadline/keyshot_submitter/adaptor_keyshot_job_template.yaml
+++ b/src/deadline/keyshot_submitter/adaptor_keyshot_job_template.yaml
@@ -35,6 +35,25 @@ parameterDefinitions:
     label: Output File Path
     groupLabel: KeyShot Settings
   description: The render output path.
+- name: OutputFormat
+  type: STRING
+  description: The render output format
+  allowedValues: 
+    [
+      "RENDER_OUTPUT_PNG",
+      "RENDER_OUTPUT_JPEG",
+      "RENDER_OUTPUT_EXR",
+      "RENDER_OUTPUT_TIFF8",
+      "RENDER_OUTPUT_TIFF32",
+      "RENDER_OUTPUT_PSD8",
+      "RENDER_OUTPUT_PSD16",
+      "RENDER_OUTPUT_PSD32"
+    ]
+  default: RENDER_OUTPUT_PNG
+  userInterface:
+    control: DROPDOWN_LIST
+    label: Output Format(Must match file extension)
+    groupLabel: KeyShot Settings
 - name: IncludeAlpha
   type: STRING
   userInterface:
@@ -75,6 +94,7 @@ steps:
         data: |
           scene_file: '{{Param.KeyShotFile}}'
           output_file_path: '{{Param.OutputFilePath}}'
+          output_format: '{{Param.OutputFormat}}'
       actions:
         onEnter:
           command: KeyShotAdaptor

--- a/src/deadline/keyshot_submitter/data_classes.py
+++ b/src/deadline/keyshot_submitter/data_classes.py
@@ -22,6 +22,9 @@ class RenderSubmitterUISettings:
 
     override_frame_range: bool = field(default=False, metadata={"sticky": True})
     frame_list: str = field(default="", metadata={"sticky": True})
+    output_name: str = field(default="", metadata={"sticky": True})
+    output_folder: str = field(default="", metadata={"sticky": True})
+    output_format: str = field(default="", metadata={"sticky": True})
     output_file_path: str = field(default="", metadata={"sticky": True})
 
     input_filenames: list[str] = field(default_factory=list, metadata={"sticky": True})
@@ -75,3 +78,17 @@ class RenderSubmitterUISettings:
                 if field.metadata.get("sticky")
             }
             json.dump(obj, fh, indent=1)
+
+
+@dataclass
+class KeyShotOutputFormat:
+    """
+    Mapping between the display name on the submitter UI, the file extension
+    to use for the output file, and the name of the KeyShot scripting property
+    used to lookup the numeric code needed to set the output format in the call
+    to lux.renderImage()
+    """
+
+    display_name: str
+    file_extension: str
+    keyshot_property_name: str

--- a/src/deadline/keyshot_submitter/default_keyshot_job_template.yaml
+++ b/src/deadline/keyshot_submitter/default_keyshot_job_template.yaml
@@ -35,6 +35,25 @@ parameterDefinitions:
     label: Output File Path
     groupLabel: KeyShot Settings
   description: The render output path.
+- name: OutputFormat
+  type: STRING
+  description: The render output format
+  allowedValues: 
+    [
+      "RENDER_OUTPUT_PNG",
+      "RENDER_OUTPUT_JPEG",
+      "RENDER_OUTPUT_EXR",
+      "RENDER_OUTPUT_TIFF8",
+      "RENDER_OUTPUT_TIFF32",
+      "RENDER_OUTPUT_PSD8",
+      "RENDER_OUTPUT_PSD16",
+      "RENDER_OUTPUT_PSD32"
+    ]
+  default: RENDER_OUTPUT_PNG
+  userInterface:
+    control: DROPDOWN_LIST
+    label: Output Format(Must match file extension)
+    groupLabel: KeyShot Settings
 - name: IncludeAlpha
   type: STRING
   userInterface:
@@ -86,10 +105,11 @@ steps:
           frame = int("{{Task.Param.Frame}}")
           lux.setAnimationFrame(frame)
           output_path = r"{{Param.OutputFilePath}}"
-          print("renderImage: %s" % output_path)
           output_path = output_path.replace("%d", str(frame))
-          print("renderImage: %s" % output_path)
-          lux.renderImage(path=output_path, opts=opts)
+          output_format_code = lux.{{Param.OutputFormat}}
+          print("Output Path: %s" % output_path)
+          print("Output Format: %s" % output_format_code)
+          lux.renderImage(path=output_path, opts=opts, format=output_format_code)
           exit()
       - name: Run
         runnable: true

--- a/src/deadline/keyshot_submitter/keyshot_render_submitter.py
+++ b/src/deadline/keyshot_submitter/keyshot_render_submitter.py
@@ -56,6 +56,7 @@ def _get_parameter_values(
 
     # Output
     parameter_values.append({"name": "OutputFilePath", "value": settings.output_file_path})
+    parameter_values.append({"name": "OutputFormat", "value": settings.output_format})
 
     parameter_values.append(
         {"name": "IncludeAlpha", "value": "true" if settings.include_alpha else "false"}
@@ -115,16 +116,16 @@ def _show_submitter(data, parent=None, f=Qt.WindowFlags()):
 
     render_settings = RenderSubmitterUISettings()
     scene_name = data["scene"]["file"]
-    if data["animation"]["duration"]:
-        frames = "%s-%s" % (0, data["animation"]["duration"])
+    if data["animation"].get("frames", None):
+        frames = "%s-%s" % (1, data["animation"]["frames"])
     else:
         frames = "%s" % data["frame"]
 
     # Set the setting defaults that come from the scene
-    output_path = Path(scene_name).parent
+    render_settings.output_folder = str(Path(scene_name).parent)
+    render_settings.output_name = data["scene"]["name"]
     render_settings.name = Path(scene_name).name
     render_settings.frame_list = frames
-    render_settings.output_file_path = str(output_path)
 
     # Load the sticky settings
     render_settings.load_sticky_settings(scene_name)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The existing KeyShot submitter was determining the default frame range incorrectly using the animation duration as the end of the frame range which was causing failures since this was giving default frame ranges like "0-3.2343" where the decimal was breaking things.

It was also unclear how to set the output file path to properly determine the output format and frame input into the file name
### What was the solution? (How)
- Fixed the frame range issue by checking the correct animation property to get the total number of frames in the animation
- Added output name(defaults to the scene name), output folder(defaults to the folder the scene is in) and output format(defaults to PNG) fields to the submission UI similar to how it's presented in KeyShot. Together these build up the output file path as `<FOLDER>\<NAME>.%d.<FORMAT>`. 
  - I could not use the existing logic that KeyShot has built-in for output file names as none of it is exposed in their scripting library.
- Adding the default PR template to the repo 

### What is the impact of this change?
- Frame range is now calculated correctly
- It's more clear how the output file path needs to be set to get a proper render back
### How was this change tested?
- Ran sample jobs with/without the adaptor on a worker and verified that the frames, output path and format were all being set correctly in the logs and downloaded outputs.
### Was this change documented?
No
### Is this a breaking change?
N/A, a release has not been cut yet for this package.