### PR TITLE
fix: layers and video output setting

### DIFF
--- a/src/deadline/keyshot_submitter/adaptor_keyshot_job_template.yaml
+++ b/src/deadline/keyshot_submitter/adaptor_keyshot_job_template.yaml
@@ -54,28 +54,6 @@ parameterDefinitions:
     control: DROPDOWN_LIST
     label: Output Format(Must match file extension)
     groupLabel: KeyShot Settings
-- name: IncludeAlpha
-  type: STRING
-  userInterface:
-    control: CHECK_BOX
-    label: Include Alpha (Transparency)
-    groupLabel: KeyShot Settings
-  description: Include alpha channel
-  default: 'true'
-  allowedValues:
-  - 'true'
-  - 'false'
-- name: RenderLayers
-  type: STRING
-  userInterface:
-    control: CHECK_BOX
-    label: Render Layers
-    groupLabel: KeyShot Settings
-  description: Include all render layers
-  default: 'true'
-  allowedValues:
-  - 'true'
-  - 'false'
 steps:
 - name: Render
   parameterSpace:

--- a/src/deadline/keyshot_submitter/data_classes.py
+++ b/src/deadline/keyshot_submitter/data_classes.py
@@ -31,9 +31,6 @@ class RenderSubmitterUISettings:
     input_directories: list[str] = field(default_factory=list, metadata={"sticky": True})
     output_directories: list[str] = field(default_factory=list, metadata={"sticky": True})
 
-    include_alpha: bool = field(default=False, metadata={"sticky": True})
-    render_layers: bool = field(default=False, metadata={"sticky": True})
-
     # developer options
     include_adaptor_wheels: bool = field(default=False, metadata={"sticky": True})
 

--- a/src/deadline/keyshot_submitter/default_keyshot_job_template.yaml
+++ b/src/deadline/keyshot_submitter/default_keyshot_job_template.yaml
@@ -54,28 +54,6 @@ parameterDefinitions:
     control: DROPDOWN_LIST
     label: Output Format(Must match file extension)
     groupLabel: KeyShot Settings
-- name: IncludeAlpha
-  type: STRING
-  userInterface:
-    control: CHECK_BOX
-    label: Include Alpha (Transparency)
-    groupLabel: KeyShot Settings
-  description: Include alpha channel
-  default: 'true'
-  allowedValues:
-  - 'true'
-  - 'false'
-- name: RenderLayers
-  type: STRING
-  userInterface:
-    control: CHECK_BOX
-    label: Render Layers
-    groupLabel: KeyShot Settings
-  description: Include all render layers
-  default: 'true'
-  allowedValues:
-  - 'true'
-  - 'false'
 steps:
 - name: RenderCommand
   parameterSpace:
@@ -98,10 +76,6 @@ steps:
         data: |
           opts = lux.getRenderOptions()
           opts.setAddToQueue(False)
-          if "{{Param.IncludeAlpha}}" == "true":
-              opts.setOutputAlphaChannel(True)
-          if "{{Param.RenderLayers}}" == "true":
-              opts.setOutputRenderLayers(True)
           frame = int("{{Task.Param.Frame}}")
           lux.setAnimationFrame(frame)
           output_path = r"{{Param.OutputFilePath}}"

--- a/src/deadline/keyshot_submitter/keyshot_render_submitter.py
+++ b/src/deadline/keyshot_submitter/keyshot_render_submitter.py
@@ -58,13 +58,6 @@ def _get_parameter_values(
     parameter_values.append({"name": "OutputFilePath", "value": settings.output_file_path})
     parameter_values.append({"name": "OutputFormat", "value": settings.output_format})
 
-    parameter_values.append(
-        {"name": "IncludeAlpha", "value": "true" if settings.include_alpha else "false"}
-    )
-    parameter_values.append(
-        {"name": "RenderLayers", "value": "true" if settings.render_layers else "false"}
-    )
-
     if settings.override_frame_range:
         frame_list = settings.frame_list
     else:

--- a/src/deadline/keyshot_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/keyshot_submitter/ui/components/scene_settings_tab.py
@@ -17,8 +17,7 @@ from PySide2.QtWidgets import (  # type: ignore
     QWidget,
 )
 
-from keyshot_submitter.data_classes import KeyShotOutputFormat  #  type: ignore
-
+from ...data_classes import KeyShotOutputFormat  #  type: ignore
 
 """
 UI widgets for the Scene Settings tab.
@@ -140,17 +139,11 @@ class SceneSettingsWidget(QWidget):
         lyt.addWidget(self.frame_override_txt, 5, 1)
         self.frame_override_chck.stateChanged.connect(self.activate_frame_override_changed)
 
-        self.include_alpha_chk = QCheckBox("Include Alpha", self)
-        lyt.addWidget(self.include_alpha_chk, 6, 0, 1, 2)
-
-        self.render_layers_chk = QCheckBox("Render Layers", self)
-        lyt.addWidget(self.render_layers_chk, 7, 0, 1, 2)
-
         if self.developer_options:
             self.include_adaptor_wheels = QCheckBox(
                 "Developer Option: Include Adaptor Wheels", self
             )
-            lyt.addWidget(self.include_adaptor_wheels, 8, 0, 1, 2)
+            lyt.addWidget(self.include_adaptor_wheels, 6, 0, 1, 2)
 
         lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 12, 0)
 

--- a/test/deadline_submitter_for_keyshot/unit/test_submitter.py
+++ b/test/deadline_submitter_for_keyshot/unit/test_submitter.py
@@ -18,8 +18,6 @@ def test_render_settings():
     a.input_filenames = ["Test Input Filenames"]
     a.input_directories = ["Test Input Directories"]
     a.output_directories = ["Test Output Directories"]
-    a.include_alpha = True
-    a.render_layers = True
     a.include_adaptor_wheels = True
     _, path = tempfile.mkstemp(suffix="json", text=True)
     a.save_sticky_settings(path)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- The alpha and render layer checkboxes were not functional
- Selecting video output in the KeyShot render options menu with certain output formats would fail renders as certain output formats can't be encoded into videos even though we only call renderImage never encodeVideo.
### What was the solution? (How)
- Remove the alpha and render layer checkboxes as those settings are preserved in the scene anyways which is where we are currently expecting everything else to be set from.
- Add a regex handler to the adaptor to inform users how to resolve the video encoding warning in logs
### What is the impact of this change?
- Less areas for confusion on why settings aren't being respected
### How was this change tested?
- Ran multiple renders and confirmed that the buttons were no longer present in the submitter and that when video output was selected with EXR format the new regex handler was used and printed a useful message to the render logs.
### Was this change documented?
No
### Is this a breaking change?
No release has been done yet, so no.