### PR TITLE
feat: add conda packages to keyshot submitter

### DIFF
--- a/keyshot_script/DeadlineCloudSubmitter.py
+++ b/keyshot_script/DeadlineCloudSubmitter.py
@@ -29,6 +29,7 @@ if not DEADLINE_KEYSHOT:
     )
 
 # save scene information to json file for submitter module to load
+keyshot_version = ".".join([str(v) for v in lux.getKeyShotVersion()])
 scene_info = lux.getSceneInfo()
 opts = lux.getRenderOptions()
 opts_dict = opts.getDict()
@@ -37,6 +38,7 @@ animation_info = lux.getAnimationInfo()
 external_files = lux.getExternalFiles()
 
 lux_info = {
+    "version": keyshot_version,
     "scene": scene_info,
     "render": opts_dict,
     "frame": current_frame,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ explicit_package_bases = true
 mypy_path = "src"
 
 [[tool.mypy.overrides]]
-module = ["PySide2.*"]
+module = ["lux.*", "PySide2.*"]
 ignore_missing_imports = true
 
 [tool.ruff]

--- a/src/deadline/keyshot_submitter/keyshot_render_submitter.py
+++ b/src/deadline/keyshot_submitter/keyshot_render_submitter.py
@@ -21,6 +21,7 @@ from .data_classes import (
     RenderSubmitterUISettings,
 )
 from .ui.components.scene_settings_tab import SceneSettingsWidget
+from ._version import version_tuple as adaptor_version_tuple
 
 
 def show_submitter(info_file):
@@ -108,6 +109,7 @@ def _show_submitter(data, parent=None, f=Qt.WindowFlags()):
         default_job_template = yaml.safe_load(fh)
 
     render_settings = RenderSubmitterUISettings()
+    keyshot_version: str = data["version"]
     scene_name = data["scene"]["file"]
     if data["animation"].get("frames", None):
         frames = "%s-%s" % (1, data["animation"]["frames"])
@@ -173,10 +175,16 @@ def _show_submitter(data, parent=None, f=Qt.WindowFlags()):
         output_directories=set(render_settings.output_directories),
     )
 
+    keyshot_major_version: str = keyshot_version.split(".")[0]
+    adaptor_version: str = ".".join(str(v) for v in adaptor_version_tuple[:2])
+    conda_packages: str = f"keyshot={keyshot_major_version}.* keyshot-openjd={adaptor_version}.*"
+
     submitter_dialog = SubmitJobToDeadlineDialog(
         job_setup_widget_type=SceneSettingsWidget,
         initial_job_settings=render_settings,
-        initial_shared_parameter_values={},
+        initial_shared_parameter_values={
+            "CondaPackages": conda_packages,
+        },
         auto_detected_attachments=auto_detected_attachments,
         attachments=attachments,
         on_create_job_bundle_callback=on_create_job_bundle_callback,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Needed to prep the submitter to use the appropriate conda packages when they're available

### What was the solution? (How)

Added the base package, and the adaptor package to the CondaPackages queue env. 

![keyshot + conda](https://github.com/casillas2/deadline-cloud-for-keyshot/assets/60796713/a7c3df5f-10ba-42aa-a5af-e46383664b31)

### What is the impact of this change?

It's ready for Conda, even if Conda isn't ready for it

### How was this change tested?

```
hatch run fmt
hatch build
hatch run lint
hatch run test
```

### Was this change documented?

N/A

### Is this a breaking change?

N/A