### PR TITLE
chore(release): fix bump workflow

### DIFF
--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -25,7 +25,7 @@ jobs:
     secrets: inherit
 
   Bump:
-    needs: Unit Tests
+    needs: UnitTests
     runs-on: ubuntu-latest
     environment: release
     permissions:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Release: Bump workflow had a syntax error, referencing UnitTests step incorrectly. See https://github.com/casillas2/deadline-cloud-for-keyshot/actions/runs/8197762023

### What was the solution? (How)
Fix the error

### What is the impact of this change?
Release workflow works

### How was this change tested?
N/A

### Was this change documented?
No

### Is this a breaking change?
No