### PR TITLE
feat: Adds telemetry events to submitter and adaptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ You can download this package from:
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
 
+## Telemetry
+
+This library collects telemetry data by default. Telemetry events contain non-personally-identifiable information that helps us understand how users interact with our software so we know what features our customers use, and/or what existing pain points are.
+
+You can opt out of telemetry data collection by either:
+
+1. Setting the environment variable: `DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true`
+2. Setting the config file: `deadline config set telemetry.opt_out true`
+
+Note that setting the environment variable supersedes the config file setting.
+
 ## License
 
 This project is licensed under the Apache-2.0 License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = ""
 requires-python = ">=3.9"
 
 dependencies = [
-    "deadline == 0.40.*",
+    "deadline == 0.41.*",
     "openjd-adaptor-runtime == 0.5.*",
 ]
 

--- a/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_client.py
+++ b/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_client.py
@@ -1,5 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from __future__ import annotations
+import lux
 import sys
 import os
 
@@ -38,6 +39,8 @@ class KeyShotClient(ClientInterface):
 
     def __init__(self, server_path: str) -> None:
         super().__init__(server_path=server_path)
+        version_str: str = ".".join(str(v) for v in lux.getKeyShotVersion()[:3])
+        print(f"KeyShotClient: KeyShot Version {version_str}")
         self.actions.update(KeyShotHandler().action_dict)
 
     def close(self, args: Optional[dict] = None) -> None:

--- a/src/deadline/keyshot_submitter/keyshot_render_submitter.py
+++ b/src/deadline/keyshot_submitter/keyshot_render_submitter.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 
 from PySide2 import QtWidgets
 
+from deadline.client import api
 from deadline.client.job_bundle.submission import AssetReferences
 from deadline.client.job_bundle._yaml import deadline_yaml_dump
 from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # pylint: disable=import-error
@@ -21,7 +22,7 @@ from .data_classes import (
     RenderSubmitterUISettings,
 )
 from .ui.components.scene_settings_tab import SceneSettingsWidget
-from ._version import version_tuple as adaptor_version_tuple
+from ._version import version, version_tuple as adaptor_version_tuple
 
 
 def show_submitter(info_file):
@@ -115,6 +116,14 @@ def _show_submitter(data, parent=None, f=Qt.WindowFlags()):
         frames = "%s-%s" % (1, data["animation"]["frames"])
     else:
         frames = "%s" % data["frame"]
+
+    # Initialize telemetry client, opt-out is respected
+    api.get_deadline_cloud_library_telemetry_client().update_common_details(
+        {
+            "deadline-cloud-for-keyshot-submitter-version": version,
+            "keyshot-version": keyshot_version,
+        }
+    )
 
     # Set the setting defaults that come from the scene
     render_settings.output_folder = str(Path(scene_name).parent)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We can't currently tell if anyone is using KeyShot submitters / adaptors

### What was the solution? (How)
Uses changes from https://github.com/casillas2/deadline-cloud/pull/205 to capture more package information when sending telemetry data, and changes from https://github.com/casillas2/deadline-cloud/pull/212 to opt out of telemetry from an environment variable.

### What is the impact of this change?
We can better tell how customers use our software and if they use KeyShot

### How was this change tested?

- ran the integrated submitter, and submitted a job, verifying it wrote telemetry (and didn't when opted out)
- ran the adaptor, confirming it wrote telemetry, huge thanks to @moorec-aws for testing this

### Was this change documented?
Updated README with opt out instructions

### Is this a breaking change?
No