### PR TITLE
feat!: update licensing configuration and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ This package has two active branches:
     ```
     set DEADLINE_CLOUD_PYTHONPATH=C:/Users/<USER>/workervenv/Lib/site-packages/openjd;C:/Users/<USER>/workervenv/Lib/site-packages/deadline;C:/Users/<USER>/workervenv/Lib/site-packages/pywin32_system32;C:/Users/<USER>/workervenv/Lib/site-packages/win32;C:/Users/<USER>/workervenv/Lib/site-packages/win32/lib;C:/Users/<USER>/workervenv/Lib/site-packages/pythonwin
     ```
-3. The adaptor expects the keyshot_headless executable is available through the PATH environment variable.  
+3. Configure licensing for KeyShot by setting the environment variable `LUXION_LICENSE_FILE=<PORT>:<ADDRESS>` to point towards the license server to use
+    e.g. `setx LUXION_LICENSE_FILE "2703@127.0.0.1"`
+4. The adaptor expects the keyshot_headless executable is available through the PATH environment variable.
     e.g. Local install: `setx PATH "%LOCALAPPDATA%\KeyShot12\bin;%PATH%"`  
     e.g. System install: `setx PATH "%PROGRAMFILES%\KeyShot12\bin;%PATH%"`
 

--- a/keyshot_script/Submit to AWS Deadline Cloud.py
+++ b/keyshot_script/Submit to AWS Deadline Cloud.py
@@ -20,7 +20,7 @@ DEADLINE_KEYSHOT = os.getenv("DEADLINE_KEYSHOT")
 
 if not DEADLINE_PYTHON:
     raise RuntimeError(
-        "Environment variable DEADLINE_PYTHON not set. Please set DEADLINE_PYTHON to point to an installed version of Python with Pyside2."
+        "Environment variable DEADLINE_PYTHON not set. Please set DEADLINE_PYTHON to point to an installation of Python with deadline and Pyside2 installed."
     )
 
 if not DEADLINE_KEYSHOT:

--- a/src/deadline/keyshot_adaptor/KeyShotAdaptor/adaptor.py
+++ b/src/deadline/keyshot_adaptor/KeyShotAdaptor/adaptor.py
@@ -337,10 +337,6 @@ class KeyShotAdaptor(Adaptor[AdaptorConfiguration]):
 
         keyshot_client_path = self._get_keyshot_client_path()
         args.append("-progress")
-        # For now we will assume that a floating license server is being used
-        # with the default port and a pro license for KeyShot
-        args.append("-floating_license_server")
-        args.append("@localhost")
         args.append("-floating_feature")
         args.append("keyshot2")
         args.append("-script")

--- a/src/deadline/keyshot_submitter/default_keyshot_job_template.yaml
+++ b/src/deadline/keyshot_submitter/default_keyshot_job_template.yaml
@@ -68,7 +68,8 @@ steps:
   script:
     actions:
       onRun:
-        command: '{{Task.File.Run}}'
+        command: powershell
+        args: ["-File", "{{Task.File.Run}}"]
     embeddedFiles:
       - name: headlessScript
         filename: headlessScript.py
@@ -90,4 +91,6 @@ steps:
         filename: run.ps1
         type: TEXT
         data: |
-          keyshot_headless -progress -floating_license_server '@localhost' -floating_feature keyshot2 '{{Param.KeyShotFile}}' -script '{{Task.File.headlessScript}}'
+          # Licensing should be configured using a floating license server specified
+          # by setting the environment variable LUXION_LICENSE_FILE=<PORT>:<ADDRESS>
+          keyshot_headless -progress -floating_feature keyshot2 '{{Param.KeyShotFile}}' -script '{{Task.File.headlessScript}}'


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We were making assumptions that KeyShot licenses would be available from a licensing tunnel configured to 2703@localhost. This isn't super flexible for users to configure their own licensing.
### What was the solution? (How)
Remove the hardcoded `@localhost` and instead provide instructions for setting up licensing using the environment variable `LUXION_LICENSE_FILE`
### What is the impact of this change?
Easier and more flexible setup for licensing with the KeyShot adaptor
### How was this change tested?
Configured licensing on a Windows machine by setting the environment variable and running the adaptor to verify that it could pull a KeyShot license from my configured floating license server
  - Used a fresh install of KeyShot as well
### Was this change documented?
No
### Is this a breaking change?
If someone was relying on localhost being assumed for licensing then yes