### PR TITLE
feat: swap to qtpy and support pyside6

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ This package provides a KeyShot plugin script that creates jobs for AWS Deadline
 
 ### Using the KeyShot Submitter
 
-1. Install deadline-cloud and PySide2
+1. Install deadline and Pyside6
+    - e.g. `pip install deadline[gui]`
 2. Copy or link the file `deadline-cloud-for-keyshot/keyshot_script/Submit to AWS Deadline Cloud.py` to the KeyShot scripts folder.
     - e.g. On Windows `C:/Users/<USER>/Documents/KeyShot 12/Scripts`
 3. Set the following environment variables

--- a/keyshot_script/Submit to AWS Deadline Cloud.py
+++ b/keyshot_script/Submit to AWS Deadline Cloud.py
@@ -20,7 +20,7 @@ DEADLINE_KEYSHOT = os.getenv("DEADLINE_KEYSHOT")
 
 if not DEADLINE_PYTHON:
     raise RuntimeError(
-        "Environment variable DEADLINE_PYTHON not set. Please set DEADLINE_PYTHON to point to an installation of Python with deadline and Pyside2 installed."
+        "Environment variable DEADLINE_PYTHON not set. Please set DEADLINE_PYTHON to point to an installation of Python with deadline and Pyside6 installed."
     )
 
 if not DEADLINE_KEYSHOT:
@@ -52,7 +52,15 @@ with open(info_file, "w") as f:
 
 
 def show_submitter():
-    subprocess.run([DEADLINE_PYTHON, DEADLINE_KEYSHOT, info_file])
+    try:
+        subprocess.run(
+            [DEADLINE_PYTHON, DEADLINE_KEYSHOT, info_file],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"AWS Deadline Cloud KeyShot submitter could not open: {e.stderr}")
 
 
 show_submitter()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ explicit_package_bases = true
 mypy_path = "src"
 
 [[tool.mypy.overrides]]
-module = ["lux.*", "PySide2.*"]
+module = ["lux.*", "qtpy.*"]
 ignore_missing_imports = true
 
 [tool.ruff]

--- a/src/deadline/keyshot_submitter/keyshot_render_submitter.py
+++ b/src/deadline/keyshot_submitter/keyshot_render_submitter.py
@@ -6,7 +6,7 @@ from typing import Any, Optional
 import yaml  # type: ignore[import]
 from copy import deepcopy
 
-from PySide2 import QtWidgets
+from qtpy import QtWidgets
 
 from deadline.client import api
 from deadline.client.job_bundle.submission import AssetReferences
@@ -16,7 +16,7 @@ from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # pylint
     JobBundlePurpose,
 )
 from deadline.client.exceptions import DeadlineOperationError
-from PySide2.QtCore import Qt  # pylint: disable=import-error
+from qtpy.QtCore import Qt  # type: ignore
 
 from .data_classes import (
     RenderSubmitterUISettings,

--- a/src/deadline/keyshot_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/keyshot_submitter/ui/components/scene_settings_tab.py
@@ -2,8 +2,8 @@
 import os
 from pathlib import Path
 
-from PySide2.QtCore import QSize, Qt  # type: ignore
-from PySide2.QtWidgets import (  # type: ignore
+from qtpy.QtCore import QSize, Qt  # type: ignore
+from qtpy.QtWidgets import (  # type: ignore
     QComboBox,
     QCheckBox,
     QFileDialog,
@@ -53,7 +53,6 @@ class FileSearchLineEdit(QWidget):
 
         lyt = QHBoxLayout(self)
         lyt.setContentsMargins(0, 0, 0, 0)
-        lyt.setMargin(0)
 
         self.edit = QLineEdit(self)
         self.btn = QPushButton("...", parent=self)
@@ -186,7 +185,7 @@ class SceneSettingsWidget(QWidget):
         """
         Set the activated/deactivated status of the Frame override text box
         """
-        self.frame_override_txt.setEnabled(state == Qt.Checked)
+        self.frame_override_txt.setEnabled(Qt.CheckState(state) == Qt.Checked)
 
     def output_file_path_changed(self):
         """

--- a/test/deadline_submitter_for_keyshot/__init__.py
+++ b/test/deadline_submitter_for_keyshot/__init__.py
@@ -5,10 +5,6 @@ from unittest.mock import MagicMock
 # we must mock UI code
 mock_modules = [
     "deadline.client.ui.deadline_authentication_status",
-    "PySide2",
-    "PySide2.QtCore",
-    "PySide2.QtGui",
-    "PySide2.QtWidgets",
     "qtpy",
     "qtpy.QtCore",
     "qtpy.QtWidgets",

--- a/test/deadline_submitter_for_keyshot/unit/__init__.py
+++ b/test/deadline_submitter_for_keyshot/unit/__init__.py
@@ -5,10 +5,10 @@ from unittest.mock import MagicMock
 
 # we must mock UI code
 mock_modules = [
-    "PySide2",
-    "PySide2.QtCore",
-    "PySide2.QtGui",
-    "PySide2.QtWidgets",
+    "qtpy",
+    "qtpy.QtCore",
+    "qtpy.QtGui",
+    "qtpy.QtWidgets",
 ]
 
 for module in mock_modules:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We were locked to just Pyside2 support which limited the submitter to only being able to run with Python < 3.11.
### What was the solution? (How)
Use qtpy instead so that Pyside2 can still be used, or Pyside6, or any other Qt package.
### What is the impact of this change?
More flexibility and Pyside6 can now be used(`pip install deadline[gui]` brings in pyside6-essentials)
### How was this change tested?
Ran the submitter using both Pyside2 and Pyside6 to submit a job
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*