### PR TITLE
feat: add KeyShot 2024 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ AWS Deadline Cloud for KeyShot is a python package that allows users to create [
 ## Compatibility
 
 This library requires:
-1. KeyShot 2023
+1. KeyShot 2023 or 2024
 1. Python 3.9 or higher; and
 1. Windows, or a macOS operating system.
 
@@ -28,7 +28,7 @@ This package provides a KeyShot plugin script that creates jobs for AWS Deadline
 1. Install deadline and Pyside6
     - e.g. `pip install deadline[gui]`
 2. Copy or link the file `deadline-cloud-for-keyshot/keyshot_script/Submit to AWS Deadline Cloud.py` to the KeyShot scripts folder.
-    - e.g. On Windows `C:/Users/<USER>/Documents/KeyShot 12/Scripts`
+    - e.g. On Windows `C:/Users/<USER>/Documents/KeyShot/Scripts`
 3. Set the following environment variables
     - Set the environment variable `DEADLINE_PYTHON` as the path to the Python installation where deadline-cloud and PySide2 were installed in step 1.
       - e.g. On Windows if using Python 3.10 it might be `set DEADLINE_PYTHON=C:/Users/<USER>/AppData/Local/Programs/Python/Python310/python`
@@ -70,8 +70,8 @@ Jobs created by the submitter use this adaptor by default.
 3. Configure licensing for KeyShot by setting the environment variable `LUXION_LICENSE_FILE=<PORT>:<ADDRESS>` to point towards the license server to use
     - e.g. `setx LUXION_LICENSE_FILE "2703@127.0.0.1"`
 4. The adaptor expects the keyshot_headless executable is available through the PATH environment variable.
-    - e.g. Local install: `setx PATH "%LOCALAPPDATA%\KeyShot12\bin;%PATH%"`
-    - e.g. System install: `setx PATH "%PROGRAMFILES%\KeyShot12\bin;%PATH%"`
+    - e.g. Local install: `setx PATH "%LOCALAPPDATA%\KeyShot\bin;%PATH%"`
+    - e.g. System install: `setx PATH "%PROGRAMFILES%\KeyShot\bin;%PATH%"`
     - Verify by running `keyshot_headless -h`
 
 ## Versioning

--- a/install_builder/deadline-cloud-for-keyshot.xml
+++ b/install_builder/deadline-cloud-for-keyshot.xml
@@ -1,6 +1,6 @@
 <component>
     <name>deadline_cloud_for_keyshot</name>
-    <description>Deadline Cloud for KeyShot 12</description>
+    <description>Deadline Cloud for KeyShot 2023/2024</description>
     <detailedDescription>KeyShot plugin for submitting jobs to AWS Deadline Cloud.</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
@@ -8,7 +8,7 @@
     <folderList>
         <folder>
             <description>KeyShot Plug-in Script</description>
-            <destination>${keyshot_scripts_folder}</destination>
+            <destination>${keyshot_scripts_directory}</destination>
             <name>keyshotplugin</name>
             <platforms>all</platforms>
             <distributionFileList>
@@ -56,8 +56,6 @@
                 <setInstallerVariable name="component(deadline_cloud_for_keyshot).show" value="0"/>
             </elseActionList>
         </if>
-    </initializationActionList>
-    <readyToInstallActionList>
         <setInstallerVariable name="keyshot_installdir" value="${installdir}\Submitters\KeyShot" />
         <if>
             <conditionRuleList>
@@ -65,54 +63,55 @@
             </conditionRuleList>
             <actionList>
                 <setInstallerVariable name="keyshot_deps_platform" value="windows" />
-                <setInstallerVariable name="win_user_keyshot_script_folder" value="${user_home_directory}\Documents\KeyShot 12\Scripts" />
-                <setInstallerVariable name="win_system_keyshot_script_folder" value="${windows_folder_common_documents}\KeyShot 12\Scripts" />
-                <if>
-                    <conditionRuleList>
-                        <fileExists path="${win_user_keyshot_script_folder}" />
-                    </conditionRuleList>
-                    <actionList>
-                        <setInstallerVariable name="keyshot_scripts_folder" value="${win_user_keyshot_script_folder}" />
-                    </actionList>
-                    <elseActionList>
-                        <if>
-                            <conditionRuleList>
-                                <fileExists path="${win_system_keyshot_script_folder}" />
-                            </conditionRuleList>
-                            <actionList>
-                                <setInstallerVariable name="keyshot_scripts_folder" value="${win_system_keyshot_script_folder}" />
-                            </actionList>
-                            <elseActionList>
-                                <setInstallerVariable name="keyshot_scripts_folder" value="${keyshot_installdir}" />
-                                <showWarning text="No installation of KeyShot 12 was found. Please manually move the 'Submit to AWS Deadline Cloud.py' script into the KeyShot scripts folder to use the plug-in." />
-                            </elseActionList>
-                        </if>
-                    </elseActionList>
-                </if>
             </actionList>
         </if>
         <if>
             <conditionRuleList>
-                <platformTest type="osx"/>
+                <compareText>
+                    <text>${env(KEYSHOT)}</text>
+                    <logic>does_not_equal</logic>
+                    <value></value>
+                </compareText>
             </conditionRuleList>
             <actionList>
-                <setInstallerVariable name="keyshot_deps_platform" value="macos"/>
-                <setInstallerVariable name="mac_keyshot_scripts_folder" value="${platform_install_prefix}/Application Support/KeyShot12/Scripts"/>
+                <!-- KeyShot 2024 (and possibly beyond) env var -->
+                <setInstallerVariable name="keyshot_resources_directory" value="${env(KEYSHOT)}"/>
+            </actionList>
+            <elseActionList>
                 <if>
                     <conditionRuleList>
-                        <fileExists path="${mac_keyshot_scripts_folder}" />
+                        <compareText>
+                            <text>${env(KEYSHOT12)}</text>
+                            <logic>does_not_equal</logic>
+                            <value></value>
+                        </compareText>
                     </conditionRuleList>
                     <actionList>
-                        <setInstallerVariable name="keyshot_scripts_folder" value="${mac_keyshot_scripts_folder}"/>
+                        <!-- KeyShot 2023 env var -->
+                        <setInstallerVariable name="keyshot_resources_directory" value="${env(KEYSHOT12)}"/>
                     </actionList>
                     <elseActionList>
-                        <setInstallerVariable name="keyshot_scripts_folder" value="${keyshot_installdir}" />
-                        <showWarning text="No installation of KeyShot 12 was found. Please manually move the 'Submit to AWS Deadline Cloud.py' script into the KeyShot scripts folder to use the plug-in." />
+                        <setInstallerVariable name="keyshot_resources_directory" value=""/>
                     </elseActionList>
                 </if>
-            </actionList>
+            </elseActionList>
         </if>
-    </readyToInstallActionList>
+        <if>
+            <conditionRuleList>
+                <compareText>
+                    <text>${keyshot_resources_directory}</text>
+                    <logic>does_not_equal</logic>
+                    <value></value>
+                </compareText>
+            </conditionRuleList>
+            <actionList>
+                <setInstallerVariable name="keyshot_scripts_directory" value="${keyshot_resources_directory}\Scripts"/>
+            </actionList>
+            <elseActionList>
+                <setInstallerVariable name="keyshot_scripts_directory" value=""/>
+            </elseActionList>
+        </if>
+    </initializationActionList>
     <parameterList>
         <stringParameter name="deadline_cloud_for_keyshot_summary" ask="0" cliOptionShow="0">
             <value>Deadline Cloud for KeyShot
@@ -121,6 +120,18 @@
 - Sets the DEADLINE_KEYSHOT environment variable to point the Submit to AWS Deadline Cloud script to the submitter module
             </value>
         </stringParameter>
+        <directoryParameter>
+            <name>keyshot_scripts_directory</name>
+            <description>KeyShot Scripts Directory</description>
+            <explanation>Path to scripts directory in the KeyShot resources directory. For easiest installation, KeyShot should be installed before installing Deadline Cloud for KeyShot.</explanation>
+            <allowEmptyValue>0</allowEmptyValue>
+            <default>Will be detected from the KEYSHOT or KEYSHOT12 environment variables during installation. If neither exists and the KeyShot component is enabled, this must be input.</default>
+            <ask>yes</ask>
+            <cliOptionName>keyshot-scripts-directory</cliOptionName>
+            <cliOptionText>Path to scripts directory in the KeyShot resources directory. For easiest installation, KeyShot should be installed before installing Deadline Cloud for KeyShot.</cliOptionText>
+            <mustBeWritable>yes</mustBeWritable>
+            <mustExist>1</mustExist>
+        </directoryParameter>
     </parameterList>
     <postInstallationActionList>
         <unzip>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Add KeyShot 2024 support :)

### What was the solution? (How)
The only code specific to KeyShot 2023 is in the installer. It was assuming that KeyShot installation is done as a user install to `C:\Users\<USER>\Documents\KeyShot 12`. However, this is not always the case. The more general solution is to use the `KEYSHOT`/`KEYSHOT12` env vars to retrieve the location of the KeyShot install.

Note that we do not have Mac installers. Hence, I have removed the macOS installer code to avoid confusion.

### What is the impact of this change?
This allows more flexibility for customers in the use of Deadline Cloud for KeyShot!

### How was this change tested?
1. End to end testing in KeyShot 2024.
2. Ran the installer in different scenarios
3. Ran the installer via the CLI

#### End to end test in KeyShot 2024
1. Created a customer managed worker following the guide [here](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/manage-cmf.html)
2. Installed KeyShot 2024
3. Submitted a job via KeyShot 2024
4. Ran a worker agent, which picked up the job and successfully ran it

#### Running the installer
Ran the installer in three scenarios:
1. with the `KEYSHOT` env var (from KeyShot 2024)
5. with the `KEYSHOT12` env var (from KeyShot 2023)
6. without either env var

In cases 1 and 2, the scripts directory was autofilled in the installer and I just had to confirm the location.

![image](https://github.com/aws-deadline/deadline-cloud-for-keyshot/assets/127782171/ebb51eaa-a215-4da8-b61d-a3db71cf3801)

In case 3, I had to manually input the location. I also verified that if the location didn't exist, the installation was rejected.

![image](https://github.com/aws-deadline/deadline-cloud-for-keyshot/assets/127782171/07a39c62-2595-49c7-afb1-eace9dde9e8e)

### Ran the installer via the CLI
Ran the installer with the `--mode unattended` argument and used the `keyshot-scripts-folder` command line argument
 `$ DeadlineCloudSubmitter-windows-x64-installer.exe --enable-components deadline-cloud-for-keyshot --keyshot-scripts-directory C:\Users\test-user\Documents\KeyShot\Scripts --mode unattended`

Help entry (`DeadlineCloudSubmitter-windows-x64-installer.exe --help`):
![image](https://github.com/aws-deadline/deadline-cloud-for-keyshot/assets/127782171/8b6f8c87-ff57-430d-8eee-c4f2467f9554)

### Was this change documented?
Yes, in the `README.md`

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*