### PR TITLE
chore: update dependency parsing logic

### DIFF
--- a/scripts/_project.py
+++ b/scripts/_project.py
@@ -30,23 +30,14 @@ def get_project_dict(project_path: Optional[Path] = None) -> dict[str, Any]:
 
 class Dependency:
     name: str
-    operator: Optional[str]
-    version: Optional[str]
+    pip_requirement: str
 
     def __init__(self, dep: str):
-        components = dep.split(" ")
-        self.name = components[0]
-        if len(components) > 2:
-            self.operator = components[1]
-            self.version = components[2]
-        else:
-            self.operator = None
-            self.version = None
+        self.pip_requirement = dep.strip().split(";", maxsplit=1)[0].replace(" ", "")
+        self.name = dep.strip().split(" ", maxsplit=1)[0]
 
     def for_pip(self) -> str:
-        if self.operator is not None and self.version is not None:
-            return f"{self.name}{self.operator}{self.version}"
-        return self.name
+        return self.pip_requirement
 
     def __repr__(self) -> str:
         return self.for_pip()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Tried running `deps_bundle.py` which was resulting in the following incorrect command trying to be run:
```
'['pip', 'install', '--target', 'C:\\Users\\<USER>\\AppData\\Local\\Temp\\tmphwjdw9a0\\base_env', '--only-binary=:all:', 'deadline>=0.48.7,<']
```
### What was the solution? (How)
The recent addition to pin deadline>=0.48.7,<0.49 is what's breaking the dependency version parsing. 
This PR updates deadline-cloud-for-keyshot in the same way that deadline-cloud-for-houdini was previously updated [here](https://github.com/aws-deadline/deadline-cloud-for-houdini/pull/139)
### What is the impact of this change?
`deps_bundle.py` works again with the current changes in mainline
### How was this change tested?
Ran `deps_bundle.py` successfully with mainline checked out
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*