### PR TITLE
chore(deps): update ruff to 0.5

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -8,7 +8,7 @@ sync = "pip install -r requirements-testing.txt"
 test = "pytest {args:test}"
 typing = "mypy {args:src test}"
 style = [
-  "ruff {args:.}",
+  "ruff check {args:.}",
   "black --check --diff {args:.}",
 ]
 fmt = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,12 +90,12 @@ module = ["lux.*", "qtpy.*"]
 ignore_missing_imports = true
 
 [tool.ruff]
-ignore = [
-  "E501",
-]
 line-length = 100
 
-[tool.ruff.isort]
+[tool.ruff.lint]
+ignore = ["E501"]
+
+[tool.ruff.lint.isort]
 known-first-party = [
   "deadline",
   "openjd"
@@ -103,7 +103,6 @@ known-first-party = [
 
 [tool.black]
 line-length = 100
-
 
 [tool.pytest.ini_options]
 xfail_strict = true

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,9 +1,9 @@
+black == 24.*
 coverage[toml] == 7.*
-pytest ~= 8.2
-pytest-cov ~= 5.0
-pytest-xdist ~= 3.6
-twine ~= 5.1
-mypy ~= 1.10
-black ~= 24.4
-ruff ~= 0.4.8
-types-pyyaml ~= 6.0
+mypy == 1.*
+pytest == 8.*
+pytest-cov == 5.*
+pytest-xdist == 3.*
+ruff == 0.5.*
+types-pyyaml == 6.*
+twine == 5.*


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

ruff was failing to update since they forced the command usage of `ruff check`. ref: https://github.com/aws-deadline/deadline-cloud-for-keyshot/pull/96

### What was the solution? (How)

update the pyproject and hatch toml to support the new ruff.

In addition, I cleanup up the test deps to be more easily identify what's locked and lower the number of dependabot updates.

### What is the impact of this change?

newer ruff dep and cleaner dep pinning!

### How was this change tested?

```
hatch run fmt
hatch run lint
hatch run test
```

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*