### PR TITLE
feat: submitter prompts user to save changes before submitting

### DIFF
--- a/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
+++ b/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
@@ -359,11 +359,16 @@ def gui_submit(bundle_directory: str) -> Optional[dict[str, Any]]:
 
 def main(lux):
     if lux.isSceneChanged():
-        lux.getMessageBox(
-            title="Unsaved changes", msg="You have unsaved changes. Save your scene and try again."
+        result = lux.getInputDialog(
+            title="Unsaved changes",
+            values=[(lux.DIALOG_LABEL, "You have unsaved changes. Do you want to save your file?")],
         )
-        # Raise an exception so Keyshot shows the script's result status as "Failed" instead of "Success"
-        raise Exception("Save changes first")
+        # result is {} if the user clicks Ok and None if the user clicks cancel
+        if result is None:
+            # Raise an exception so Keyshot shows the script's result status as "Failure" instead of "Success"
+            raise Exception("Changes must be saved before submitting.")
+        else:
+            lux.saveFile()
 
     scene_file = lux.getSceneInfo()["file"]
     external_files = lux.getExternalFiles()

--- a/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
+++ b/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
@@ -357,7 +357,14 @@ def gui_submit(bundle_directory: str) -> Optional[dict[str, Any]]:
         return None
 
 
-def main():
+def main(lux):
+    if lux.isSceneChanged():
+        lux.getMessageBox(
+            title="Unsaved changes", msg="You have unsaved changes. Save your scene and try again."
+        )
+        # Raise an exception so Keyshot shows the script's result status as "Failed" instead of "Success"
+        raise Exception("Save changes first")
+
     scene_file = lux.getSceneInfo()["file"]
     external_files = lux.getExternalFiles()
     current_frame = lux.getAnimationFrame()
@@ -413,4 +420,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    main(lux)

--- a/test/keyshot_submitter/test_keyshot_submitter.py
+++ b/test/keyshot_submitter/test_keyshot_submitter.py
@@ -249,6 +249,17 @@ def test_settings_apply_submitter_settings():
 def test_unsaved_changes_prompt():
     local_mock_lux = Mock()
     local_mock_lux.isSceneChanged.return_value = True
+
+    local_mock_lux.getInputDialog.return_value = None  # emulate clicking Cancel
     with pytest.raises(Exception):
         submitter.main(local_mock_lux)
-        local_mock_lux.getMessageBox.assert_called()
+    local_mock_lux.saveFile.assert_not_called()
+
+    local_mock_lux.getInputDialog.return_value = {}  # emulate clicking Ok
+    # Raise an exception so the main() handler exits after the file save operation is called.
+    # We want to verify that the saveFile call is made, but don't want to run the rest of the
+    # submitter.
+    local_mock_lux.saveFile.side_effect = Exception()
+    with pytest.raises(Exception):
+        submitter.main(local_mock_lux)
+    local_mock_lux.saveFile.assert_called()

--- a/test/keyshot_submitter/test_keyshot_submitter.py
+++ b/test/keyshot_submitter/test_keyshot_submitter.py
@@ -1,9 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from unittest.mock import Mock
 import mock_lux  # type: ignore[import-not-found] # noqa: F401
 
 import json
 import os
 import tempfile
+import pytest
 
 
 deadline = __import__("deadline.keyshot_submitter.Submit to AWS Deadline Cloud")
@@ -242,3 +244,11 @@ def test_settings_apply_submitter_settings():
     assert sorted(settings.input_directories) == ["test_directory_2"]
     assert sorted(settings.output_directories) == ["test_directory_2", "test_directory_4"]
     assert sorted(settings.referenced_paths) == ["test_ref_path_2"]
+
+
+def test_unsaved_changes_prompt():
+    local_mock_lux = Mock()
+    local_mock_lux.isSceneChanged.return_value = True
+    with pytest.raises(Exception):
+        submitter.main(local_mock_lux)
+        local_mock_lux.getMessageBox.assert_called()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
If the user makes updates to their scene but fails to save them before submitting, their local changes won't be part of the submission.

### What was the solution? (How)
Detect when there are unsaved changes and prompt the user to save their file first.

![Screenshot 2024-07-10 at 2 29 05 PM](https://github.com/aws-deadline/deadline-cloud-for-keyshot/assets/6042774/fdcdd3f2-7aa4-4d90-956b-3bb21dfb1fbc)

### What is the impact of this change?
Local changes are always saved before submitting.

### How was this change tested?
Local testing and a unit test.

### Was this change documented?
No, not needed.

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*