### PR TITLE
fix: do not show Success status when submission is cancelled

### DIFF
--- a/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
+++ b/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
@@ -439,8 +439,8 @@ def main(lux):
     dialog_selections = options_dialog()
 
     if not dialog_selections:
-        # Dialog was cancelled. Raise an exception so Keyshot does not show the script's result status as "Success"
-        raise Exception("Job submission canceled.")
+        # Dialog was canceled. Raise an exception so Keyshot does not show the script's result status as "Success"
+        raise Exception("Submission was canceled.")
 
     scene_info = lux.getSceneInfo()
     scene_file = scene_info["file"]
@@ -496,7 +496,7 @@ def main(lux):
     if output:
         if output.get("status") == "CANCELED":
             # Raise an exception so Keyshot does not show the script's result status as "Success"
-            raise Exception("Submission was cancelled.")
+            raise Exception("Submission was canceled.")
 
         settings.apply_submitter_settings(output)
         save_sticky_settings(scene_file, settings)

--- a/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
+++ b/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
@@ -439,8 +439,8 @@ def main(lux):
     dialog_selections = options_dialog()
 
     if not dialog_selections:
-        print("Job submission canceled.")
-        return
+        # Dialog was cancelled. Raise an exception so Keyshot does not show the script's result status as "Success"
+        raise Exception("Job submission canceled.")
 
     scene_info = lux.getSceneInfo()
     scene_file = scene_info["file"]

--- a/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
+++ b/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
@@ -420,6 +420,10 @@ def main(lux):
         output = gui_submit(temp_dir)
 
     if output:
+        if output.get("status") == "CANCELED":
+            # Raise an exception so Keyshot does not show the script's result status as "Success"
+            raise Exception("Submission was cancelled.")
+
         settings.apply_submitter_settings(output)
         save_sticky_settings(scene_file, settings)
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When the submitter window is cancelled, Keyshot pops up a result window saying the script was "Successful" which is confusing/.

### What was the solution? (How)
Make the status show as "Failure" instead. "Cancelled" would be a better status, but we can't customize it and it's less confusing than "Success".

### What is the impact of this change?
![Screenshot 2024-07-10 at 4 05 08 PM](https://github.com/aws-deadline/deadline-cloud-for-keyshot/assets/6042774/5247f11d-bd84-4dd4-8e0d-6a24f36a062c)

### How was this change tested?
I cancelled a job.

### Was this change documented?
No, not needed

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*