### PR TITLE
chore: update README with latest KeyShot submitter location

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ This package provides a KeyShot plugin script that creates jobs for AWS Deadline
 ### Installing and using the KeyShot Submitter
 
 1. Run `pip install deadline[gui]`
-2. Copy the file `deadline-cloud-for-keyshot/keyshot_submitter/Submit to AWS Deadline Cloud.py` to the KeyShot scripts folder for your OS:
+2. Copy the file `deadline-cloud-for-keyshot/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py` to the KeyShot scripts folder for your OS:
     - Windows (choose one): 
-        - User scripts folder: `%USERPROFILE%/Documents/KeyShot/Scripts`
-        - System-wide scripts folder: `%PROGRAMFILES%/KeyShot/Scripts`
+        - User scripts folder e.g. `%USERPROFILE%/Documents/KeyShot/Scripts`
+        - System-wide scripts folder e.g. `%PROGRAMFILES%/KeyShot/Scripts`
     - Mac: `/Library/Application Support/KeyShot12/` or `/Library/Application Support/KeyShot/` depending on your version of Keyshot.
         - You can navigate to the folder by going to Finder, clicking the menu for Go -> Go to Folder, and typing in the folder path.
 3. Launch KeyShot. The submitter can be launched within KeyShot from `Window > Scripting Console > Scripts > Submit to AWS Deadline Cloud > Run`


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The KeyShot submitter location was incorrect in the README.

Addresses the README issue in https://github.com/aws-deadline/deadline-cloud-for-keyshot/issues/107

### What was the solution? (How)
Updated the README. Also updated the Windows scripts location described in the README to be more open/version compatible.

### What is the impact of this change?
Correct installation instructions.

### How was this change tested?
N/A

### Was this change documented?
N/A - this is documentation.

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*