### PR TITLE
chore: create adaptor packaging artifact script

### DIFF
--- a/scripts/create_adaptor_packaging_artifact.sh
+++ b/scripts/create_adaptor_packaging_artifact.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+set -xeou pipefail
+
+APP_LOWERCASE=keyshot
+APP_PASCAL_CASE=KeyShot
+ADAPTOR_NAME=deadline-cloud-for-$APP_LOWERCASE
+
+# This script generates an tar.gz artifact from $ADAPTOR_NAME and its dependencies
+# that can be used to create a package for running the adaptor.
+
+SCRIPTDIR=$(realpath $(dirname $0))
+
+SOURCE=0
+# Python 3.11 is for https://vfxplatform.com/ CY2024
+PYTHON_VERSION=3.11
+CONDA_PLATFORM=win-64
+TAR_BASE=
+
+while [ $# -gt 0 ]; do
+    case "${1}" in
+    --source) SOURCE=1 ; shift ;;
+    --platform) CONDA_PLATFORM="$2" ; shift 2 ;;
+    --python) PYTHON_VERSION="$2" ; shift 2 ;;
+    --tar-base) TAR_BASE="$2" ; shift 2 ;;
+    *) echo "Unexpected option: $1"; exit 1 ;;
+  esac
+done
+
+if [ "$CONDA_PLATFORM" = "linux-64" ]; then
+    PYPI_PLATFORM=manylinux2014_x86_64
+elif [ "$CONDA_PLATFORM" = "win-64" ]; then
+    PYPI_PLATFORM=win_amd64
+elif [ "$CONDA_PLATFORM" = "osx-64" ]; then
+    PYPI_PLATFORM=macosx_10_9_x86_64
+else
+    echo "Unknown Conda operating system option --platform $CONDA_PLATFORM"
+    exit 1
+fi
+
+if [ "$TAR_BASE" = "" ]; then
+    TAR_BASE=$SCRIPTDIR/../$APP_LOWERCASE-openjd-py$PYTHON_VERSION-$CONDA_PLATFORM
+fi
+
+# Create a temporary prefix
+WORKDIR=$(mktemp -d adaptor-pkg.XXXXXXXXXX)
+function cleanup_workdir {
+    echo "Cleaning up $WORKDIR"
+    rm -rf $WORKDIR
+}
+trap cleanup_workdir EXIT
+
+PREFIX=$WORKDIR/prefix
+
+if [ "$CONDA_PLATFORM" = "win-64" ]; then
+    BINDIR=$PREFIX/Library/bin
+    PACKAGEDIR=$PREFIX/Library/opt/$ADAPTOR_NAME
+else
+    BINDIR=$PREFIX/bin
+    PACKAGEDIR=$PREFIX/opt/$ADAPTOR_NAME
+fi
+
+
+mkdir -p $PREFIX
+mkdir -p $PACKAGEDIR
+mkdir -p $BINDIR
+
+# Install the adaptor into the virtual env
+if [ $SOURCE = 1 ]; then
+    # In source mode, openjd-adaptor-runtime-for-python must be alongside this adaptor source
+    RUNTIME_INSTALLABLE=$SCRIPTDIR/../../openjd-adaptor-runtime-for-python
+    CLIENT_INSTALLABLE=$SCRIPTDIR/../../deadline-cloud
+    ADAPTOR_INSTALLABLE=$SCRIPTDIR/..
+
+    if [ "$CONDA_PLATFORM" = "win-64" ]; then
+        DEPS="pyyaml jsonschema pywin32"
+    else
+        DEPS="pyyaml jsonschema"
+    fi
+
+    for DEP in $DEPS; do
+        pip install \
+            --target $PACKAGEDIR \
+            --platform $PYPI_PLATFORM \
+            --python-version $PYTHON_VERSION \
+            --ignore-installed \
+            --only-binary=:all: \
+            $DEP
+    done
+
+    pip install \
+        --target $PACKAGEDIR \
+        --platform $PYPI_PLATFORM \
+        --python-version $PYTHON_VERSION \
+        --ignore-installed \
+        --no-deps \
+        $RUNTIME_INSTALLABLE
+
+    # Install these two at the same time otherwise they overwrite eachother
+    pip install \
+        --target $PACKAGEDIR \
+        --platform $PYPI_PLATFORM \
+        --python-version $PYTHON_VERSION \
+        --only-binary=:all: \
+        --ignore-installed \
+        $ADAPTOR_INSTALLABLE $CLIENT_INSTALLABLE
+else
+    # In PyPI mode, PyPI and/or a CodeArtifact must have these packages
+    RUNTIME_INSTALLABLE=openjd-adaptor-runtime
+    CLIENT_INSTALLABLE=deadline
+    ADAPTOR_INSTALLABLE=$ADAPTOR_NAME
+
+    pip install \
+        --target $PACKAGEDIR \
+        --platform $PYPI_PLATFORM \
+        --python-version $PYTHON_VERSION \
+        --ignore-installed \
+        --no-deps \
+        $RUNTIME_INSTALLABLE
+
+    # Install these two at the same time otherwise they overwrite eachother
+    pip install \
+        --target $PACKAGEDIR \
+        --platform $PYPI_PLATFORM \
+        --python-version $PYTHON_VERSION \
+        --ignore-installed \
+        --only-binary=:all: \
+        $ADAPTOR_INSTALLABLE $CLIENT_INSTALLABLE
+fi
+
+
+# Remove the submitter code
+rm -r $PACKAGEDIR/deadline/*_submitter
+
+# Remove the bin dir if there is one
+if [ -d $PACKAGEDIR/bin ]; then
+    rm -r $PACKAGEDIR/bin
+fi
+
+PYSCRIPT="
+import sys
+from deadline.${APP_LOWERCASE}_adaptor.${APP_PASCAL_CASE}Adaptor.__main__ import main
+sys.exit(main())
+"
+
+cat <<EOF > $BINDIR/$APP_LOWERCASE-openjd
+#!/usr/bin/env python3.11
+$PYSCRIPT
+EOF
+
+# Temporary
+cp $BINDIR/$APP_LOWERCASE-openjd $BINDIR/${APP_PASCAL_CASE}Adaptor
+
+chmod u+x $BINDIR/$APP_LOWERCASE-openjd $BINDIR/${APP_PASCAL_CASE}Adaptor
+
+if [ $CONDA_PLATFORM = "win-64" ]; then
+    # Install setuptools to get cli-64.exe
+    mkdir -p $WORKDIR/tmp
+    pip install \
+        --target $WORKDIR/tmp \
+        --platform $PYPI_PLATFORM \
+        --python-version $PYTHON_VERSION \
+        --ignore-installed \
+        --no-deps \
+        setuptools
+
+    # Use setuptools' cli-64.exe to define the entry point
+    cat <<EOF > $BINDIR/$APP_LOWERCASE-openjd-script.py
+#!C:\\Path\\To\\Python.exe
+$PYSCRIPT
+EOF
+    cp $WORKDIR/tmp/setuptools/cli-64.exe $BINDIR/$APP_LOWERCASE-openjd.exe
+fi
+
+# Everything between the first "-" and the next "+" is the package version number
+PACKAGEVER=$(cd $PACKAGEDIR; echo deadline_cloud_for*)
+PACKAGEVER=${PACKAGEVER#*-}
+PACKAGEVER=${PACKAGEVER%+*}
+echo "Package version number is $PACKAGEVER"
+
+# Create the tar artifact
+GIT_TIMESTAMP="$(env TZ=UTC git log -1 --date=iso-strict-local --format="%ad")"
+pushd $PREFIX
+# See https://reproducible-builds.org/docs/archives/ for information about
+# these options
+#tar --mtime=$GIT_TIMESTAMP \
+#     --sort=name \
+#     --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+#    --owner=0 --group=0 --numeric-owner \
+#    -cf $TAR_BASE .
+# TODO Switch to the above command once the build environment has tar version > 1.28
+tar --owner=0 --group=0 --numeric-owner \
+    -cf $TAR_BASE-$PACKAGEVER.tar.gz .
+sha256sum $TAR_BASE-$PACKAGEVER.tar.gz
+popd

--- a/scripts/create_adaptor_packaging_artifact.sh
+++ b/scripts/create_adaptor_packaging_artifact.sh
@@ -53,21 +53,18 @@ trap cleanup_workdir EXIT
 PREFIX=$WORKDIR/prefix
 
 if [ "$CONDA_PLATFORM" = "win-64" ]; then
-    BINDIR=$PREFIX/Library/bin
     PACKAGEDIR=$PREFIX/Library/opt/$ADAPTOR_NAME
 else
-    BINDIR=$PREFIX/bin
     PACKAGEDIR=$PREFIX/opt/$ADAPTOR_NAME
 fi
 
 
 mkdir -p $PREFIX
 mkdir -p $PACKAGEDIR
-mkdir -p $BINDIR
 
 # Install the adaptor into the virtual env
 if [ $SOURCE = 1 ]; then
-    # In source mode, openjd-adaptor-runtime-for-python must be alongside this adaptor source
+    # In source mode, openjd-adaptor-runtime-for-python and deadline-cloud must be alongside this adaptor source
     RUNTIME_INSTALLABLE=$SCRIPTDIR/../../openjd-adaptor-runtime-for-python
     CLIENT_INSTALLABLE=$SCRIPTDIR/../../deadline-cloud
     ADAPTOR_INSTALLABLE=$SCRIPTDIR/..
@@ -135,41 +132,6 @@ rm -r $PACKAGEDIR/deadline/*_submitter
 # Remove the bin dir if there is one
 if [ -d $PACKAGEDIR/bin ]; then
     rm -r $PACKAGEDIR/bin
-fi
-
-PYSCRIPT="
-import sys
-from deadline.${APP_LOWERCASE}_adaptor.${APP_PASCAL_CASE}Adaptor.__main__ import main
-sys.exit(main())
-"
-
-cat <<EOF > $BINDIR/$APP_LOWERCASE-openjd
-#!/usr/bin/env python3.11
-$PYSCRIPT
-EOF
-
-# Temporary
-cp $BINDIR/$APP_LOWERCASE-openjd $BINDIR/${APP_PASCAL_CASE}Adaptor
-
-chmod u+x $BINDIR/$APP_LOWERCASE-openjd $BINDIR/${APP_PASCAL_CASE}Adaptor
-
-if [ $CONDA_PLATFORM = "win-64" ]; then
-    # Install setuptools to get cli-64.exe
-    mkdir -p $WORKDIR/tmp
-    pip install \
-        --target $WORKDIR/tmp \
-        --platform $PYPI_PLATFORM \
-        --python-version $PYTHON_VERSION \
-        --ignore-installed \
-        --no-deps \
-        setuptools
-
-    # Use setuptools' cli-64.exe to define the entry point
-    cat <<EOF > $BINDIR/$APP_LOWERCASE-openjd-script.py
-#!C:\\Path\\To\\Python.exe
-$PYSCRIPT
-EOF
-    cp $WORKDIR/tmp/setuptools/cli-64.exe $BINDIR/$APP_LOWERCASE-openjd.exe
 fi
 
 # Everything between the first "-" and the next "+" is the package version number

--- a/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_client.py
+++ b/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_client.py
@@ -21,6 +21,8 @@ if "openjd" not in sys.modules.keys():
                 print("add_dll_directory failed: %s" % p)
         sys.path.append(p)
 
+# Required for making pywin32 portable
+import pywin32_bootstrap  # type: ignore # noqa: F401 E402
 
 from types import FrameType  # noqa: E402
 from typing import Optional  # noqa: E402

--- a/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_client.py
+++ b/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_client.py
@@ -21,7 +21,7 @@ if "openjd" not in sys.modules.keys():
                 print("add_dll_directory failed: %s" % p)
         sys.path.append(p)
 
-# Required for making pywin32 portable
+# Required for making pywin32 portable. See https://github.com/mhammond/pywin32/blob/main/win32/Lib/pywin32_bootstrap.py
 import pywin32_bootstrap  # type: ignore # noqa: F401 E402
 
 from types import FrameType  # noqa: E402


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need a script to package up this adapter as part of the conda build process.

### What was the solution? (How)
Make a packaging script. Most code was pulled from [this PR](https://github.com/aws-deadline/deadline-cloud-for-keyshot/pull/105) but with some tweaks to clean up some bits that did not end up being used and to make pywin32 portable.

### What is the impact of this change?
We can build a conda package for the Keyshot adapter.

### How was this change tested?
I built the artifact, built a conda package from it, and then ran a render using the adapter.

### Was this change documented?
Not needed.

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*