### PR TITLE
fix: add default values for conda packages and channels

### DIFF
--- a/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
+++ b/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
@@ -448,7 +448,6 @@ def get_ksp_bundle_files(directory: str) -> Tuple[str, list[str]]:
 
 
 def main(lux):
-
     if lux.isSceneChanged():
         result = lux.getInputDialog(
             title="Unsaved changes",
@@ -509,8 +508,9 @@ def main(lux):
             settings.parameter_values.append({"name": "KeyShotFile", "value": scene_file})
 
         # Add default values for Conda
+        major_version, minor_version = lux.getKeyShotDisplayVersion()
         settings.parameter_values.append(
-            {"name": "CondaPackages", "value": "keyshot=2024.* keyshot-openjd=0.1.*"}
+            {"name": "CondaPackages", "value": f"keyshot={major_version}.* keyshot-openjd=0.1.*"}
         )
         settings.parameter_values.append({"name": "CondaChannels", "value": "deadline-cloud"})
 

--- a/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
+++ b/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
@@ -55,9 +55,11 @@ class Settings:
 
         for param in input_parameter_values:
             if param.get("name") and param.get("value"):
-                # don't re-use KeyShotFile param if the render settings are copied from one file to another
-                if param["name"] != "KeyShotFile":
-                    updated_parameter_values[param["name"]] = param["value"]
+                # Don't re-use KeyShotFile param if the render settings are copied from one file to another
+                # Don't preserve conda settings so the Keyshot version can be updated by updating the submitter
+                if param["name"] in ["KeyShotFile", "CondaPackages", "CondaChannels"]:
+                    continue
+                updated_parameter_values[param["name"]] = param["value"]
 
         self.parameter_values = [
             {"name": parameter_name, "value": updated_parameter_values[parameter_name]}
@@ -482,6 +484,12 @@ def main(lux):
             settings.parameter_values.append({"name": "KeyShotFile", "value": temp_scene_file})
         else:
             settings.parameter_values.append({"name": "KeyShotFile", "value": scene_file})
+
+        # Add default values for Conda
+        settings.parameter_values.append(
+            {"name": "CondaPackages", "value": "keyshot=2024.* keyshot-openjd=0.1.*"}
+        )
+        settings.parameter_values.append({"name": "CondaChannels", "value": "deadline-cloud"})
 
         job_template = construct_job_template(scene_name)
         asset_references = construct_asset_references(settings)

--- a/test/keyshot_submitter/test_keyshot_submitter.py
+++ b/test/keyshot_submitter/test_keyshot_submitter.py
@@ -152,8 +152,10 @@ def test_settings_apply_sticky_settings():
     settings.apply_sticky_settings(
         {
             "parameterValues": [
-                # input KeyShotFile from sticky settings should be ignored
+                # Some parameters should not be sticky
                 {"name": "KeyShotFile", "value": "scene_file_from_sticky_settings"},
+                {"name": "CondaPackages", "value": "keyshot=2023.* keyshot-openjd=0.0.1"},
+                {"name": "CondaChannels", "value": "conda-forge"},
             ],
             "inputFilenames": ["test_filename_20"],
             "inputDirectories": ["test_directory_21"],


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The CLI-based submitter should provide defaults for conda if the queue has a conda queue environment,

### What was the solution? (How)
Add defaults.

### What is the impact of this change?
The submitter works easily with conda without fiddling with conda settings.

### How was this change tested?
I submitted a job that used the defaults to a queue that had the default queue environment and it worked. I also tested it with a queue that did not have a queue environment.

### Was this change documented?
Not needed.

### Is this a breaking change?
No, it adds back a feature that's been missing since the submitter refactor. Note: it defaults to a different Keyshot version scheme that the old defaults.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*