### PR TITLE
fix: remove submitter dependencies that aren't available in KeyShot Python

### DIFF
--- a/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
+++ b/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
@@ -6,13 +6,10 @@
 import json
 import os
 import platform
-import shlex
-import shutil
 import subprocess
 import tempfile
 import glob
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, Optional, Tuple
 
 import lux
@@ -279,9 +276,14 @@ def dump_json_to_dir(contents: dict, directory: str, filename: str) -> None:
         file.write(json.dumps(contents))
 
 
+def substitute_suffix(path: str, suffix: str) -> str:
+    root, _ext = os.path.splitext(path)
+    return root + suffix
+
+
 def load_sticky_settings(scene_filename: str) -> Optional[dict]:
-    sticky_settings_filename = Path(scene_filename).with_suffix(RENDER_SUBMITTER_SETTINGS_FILE_EXT)
-    if sticky_settings_filename.exists() and sticky_settings_filename.is_file():
+    sticky_settings_filename = substitute_suffix(scene_filename, RENDER_SUBMITTER_SETTINGS_FILE_EXT)
+    if os.path.exists(sticky_settings_filename) and os.path.isfile(sticky_settings_filename):
         try:
             with open(sticky_settings_filename, encoding="utf8") as f:
                 return json.load(f)
@@ -297,7 +299,7 @@ def load_sticky_settings(scene_filename: str) -> Optional[dict]:
 
 
 def save_sticky_settings(scene_file: str, settings: Settings):
-    sticky_settings_filename = Path(scene_file).with_suffix(RENDER_SUBMITTER_SETTINGS_FILE_EXT)
+    sticky_settings_filename = substitute_suffix(scene_file, RENDER_SUBMITTER_SETTINGS_FILE_EXT)
     with open(sticky_settings_filename, "w", encoding="utf8") as f:
         json.dump(settings.output_sticky_settings(), f, indent=2)
 
@@ -314,7 +316,7 @@ def gui_submit(bundle_directory: str) -> Optional[dict[str, Any]]:
                     shell_executable,
                     "-i",
                     "-c",
-                    f'echo "START_DEADLINE_OUTPUT";deadline bundle gui-submit {shlex.quote(bundle_directory)} --output json',
+                    f"echo \"START_DEADLINE_OUTPUT\";deadline bundle gui-submit '{bundle_directory}' --output json",
                 ],
                 check=True,
                 capture_output=True,
@@ -401,9 +403,30 @@ def get_ksp_bundle_files(directory: str) -> Tuple[str, list[str]]:
 
     ksp_dir = os.path.join(directory, "ksp")
     unpack_dir = os.path.join(directory, "unpack")
+    ksp_archive = save_ksp_bundle(ksp_dir, "temp_deadline_cloud.zip")
+    if platform.system() == "Darwin" or platform.system() == "Linux":
+        subprocess.run(
+            ["unzip", ksp_archive, "-d", unpack_dir],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    else:
+        subprocess.run(
+            [
+                "PowerShell",
+                "-Command",
+                "Expand-Archive",
+                "-Path",
+                ksp_archive,
+                "-DestinationPath",
+                unpack_dir,
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
 
-    ksp_archive = save_ksp_bundle(ksp_dir, "temp_deadline_cloud.ksp")
-    shutil.unpack_archive(ksp_archive, unpack_dir, "zip")
     input_filenames = [
         os.path.join(unpack_dir, file)
         for file in os.listdir(unpack_dir)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Addresses https://github.com/aws-deadline/deadline-cloud-for-keyshot/issues/107

### What was the solution? (How)
Replaced each of the unavailable libraries with alternate approaches.

Note that any OS which can run KeyShot 2023 or 2024 can run `unzip` (Mac) or `Expand-Archive` (Windows).

### What is the impact of this change?
Customers are able to submit in KeyShot Python.

### How was this change tested?
Uninstalled system Python 3.11 from my (Windows) machine. Submitted jobs with and without the external file options.
Also tested from a Mac machine.

### Was this change documented?
No, not required.

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*