### PR TITLE
feat: speedup KSP extraction on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ AWS Deadline Cloud for KeyShot is a python package that allows users to create [
 This library requires:
 1. KeyShot 2023 or 2024
 1. Python 3.9 or higher; and
-1. Windows, or a macOS operating system.
+1. Windows or macOS operating system.
 
 ## Submitter
 

--- a/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
+++ b/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
@@ -418,6 +418,8 @@ def get_ksp_bundle_files(directory: str) -> Tuple[str, list[str]]:
             [
                 "PowerShell",
                 "-Command",
+                '$ProgressPreference = "SilentlyContinue"',  # don't display progress bar, up to 4x speedup
+                ";",
                 "Expand-Archive",
                 "-Path",
                 ksp_archive,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
It was noted that progress reporting dramatically affected the speed of zip extraction using `Expand-Archive` in Windows PowerShell.

### What was the solution? (How)
While progress reporting is nice to have, so is fast submission speed. I tested extraction times with the [sample Keyframe Animation (robot head) scene from KeyShot](https://www.keyshot.com/keyshot-studio/scenes/) and discovered that extraction time was sped up by 2.5x when progress reporting was not used. From previous experience, the speedup can up to 4x depending on the size of files, the machine used, etc.

We believe that customers value fast unzipping much more than progress reporting while unzipping, so I have applied the speedup by default.

### What is the impact of this change?
Speedup of submission using Deadline Cloud for KeyShot.

### How was this change tested?
Used this with the [KeyFrame Animation scene form KeyShot](https://www.keyshot.com/keyshot-studio/scenes/) and confirmed it worked. 

### Was this change documented?
No, not required

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*