### PR TITLE
ci: package and publish Keyshot plugin to the GitHub release

### DIFF
--- a/.github/actions/bump_precommit_hook/action.yml
+++ b/.github/actions/bump_precommit_hook/action.yml
@@ -1,0 +1,16 @@
+inputs:
+  semver:
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+  - name: Update plugin Version
+    shell: bash
+    run: |
+      sed -i "s/^# VERSION.*/# VERSION ${{inputs.semver}}/" ./src/deadline/keyshot_submitter/Submit\ to\ AWS\ Deadline\ Cloud.py
+      major=$(printf ${{inputs.semver}} | cut -d '.' -f1)
+      minor=$(printf ${{inputs.semver}} | cut -d '.' -f2)
+      sed -i "s/keyshot-openjd=[0-9]*.[0-9]*.\\*/keyshot-openjd=$major.$minor.\\*/" ./src/deadline/keyshot_submitter/Submit\ to\ AWS\ Deadline\ Cloud.py
+      git add ./src/deadline/keyshot_submitter/Submit\ to\ AWS\ Deadline\ Cloud.py 

--- a/.github/actions/prepush_release_hook/action.yml
+++ b/.github/actions/prepush_release_hook/action.yml
@@ -1,0 +1,18 @@
+inputs:
+  semver:
+    required: true
+    type: string
+  tag:
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+  - name: Zip submitter plugin
+    shell: bash
+    run: |
+      mkdir dist_extras
+      cd src/deadline/keyshot_submitter
+      zip -r  ../../../dist_extras/keyshot_submitter_plugin_${{inputs.semver}}.zip .
+      cd ../../../


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
1. Version files in keyshot script are not updated when a new version is released
2. Users are required to git clone the release branch to use the latest submitter.

### What was the solution? (How)
1. Update the script and adaptor version in the Submit to AWS Deadline Cloud.py script.
2. Zip the contenets of `keyshot_submitter` into the dist_extras directory during the release proces.

### What is the impact of this change?
1. Proper versions updated in plugin file when we do a release
2. Users can access the plugin from the release page.

### How was this change tested?
Tested in a development environment using the [reusable_bump](https://github.com/aws-deadline/.github/blob/mainline/.github/workflows/reusable_bump.yml) and [reusable publish](https://github.com/aws-deadline/.github/blob/mainline/.github/workflows/reusable_publish.yml) workflows.

* Confirmed that the versions are updated properly in the ChangeLog PR.
* Confirmed that the zip exist on the release page with the expected contents.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*