### PR TITLE
fix: use consistent version strings for Keyshot

### DIFF
--- a/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_client.py
+++ b/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_client.py
@@ -43,8 +43,8 @@ class KeyShotClient(ClientInterface):
 
     def __init__(self, server_path: str) -> None:
         super().__init__(server_path=server_path)
-        version_str: str = ".".join(str(v) for v in lux.getKeyShotVersion()[:3])
-        print(f"KeyShotClient: KeyShot Version {version_str}")
+        major_version, minor_version = lux.getKeyShotDisplayVersion()
+        print(f"KeyShotClient: KeyShot Version {major_version}.{minor_version}")
         self.actions.update(KeyShotHandler().action_dict)
 
     def close(self, args: Optional[dict] = None) -> None:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Keyshot adapter prints out the Keyshot version number as 13.0.0 instead of 2024.1. The version numbers are equivalent, but are confusing when the submitter and conda packages use the second version scheme.

Fixes: https://github.com/aws-deadline/deadline-cloud-for-keyshot/issues/119

### What was the solution? (How)
Update the version number scheme to be consistent.

### What is the impact of this change?
Clearer logs.

### How was this change tested?
I ran just the changed lines in Keyshot and saw that it printed:
```
KeyShotClient: KeyShot Version 2024.2
```

### Was this change documented?
Not needed.

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*