### PR TITLE
fix: update installer to locate KeyShot scripts directory in more cases

### DIFF
--- a/install_builder/deadline-cloud-for-keyshot.xml
+++ b/install_builder/deadline-cloud-for-keyshot.xml
@@ -53,7 +53,7 @@
             </conditionRuleList>
             <actionList>
                 <!-- KeyShot 2024 (and possibly beyond) env var -->
-                <setInstallerVariable name="keyshot_resources_directory" value="${env(KEYSHOT)}"/>
+                <setInstallerVariable name="keyshot_scripts_directory" value="${env(KEYSHOT)}\Scripts"/>
             </actionList>
             <elseActionList>
                 <if>
@@ -66,29 +66,18 @@
                     </conditionRuleList>
                     <actionList>
                         <!-- KeyShot 2023 env var -->
-                        <setInstallerVariable name="keyshot_resources_directory" value="${env(KEYSHOT12)}"/>
+                        <setInstallerVariable name="keyshot_scripts_directory" value="${env(KEYSHOT12)}\Scripts"/>
                     </actionList>
                     <elseActionList>
-                        <setInstallerVariable name="keyshot_resources_directory" value=""/>
+                        <!-- KeyShot 2024 default location as a fallback -->
+                        <setInstallerVariable name="keyshot_scripts_directory" value="${user_home_directory}\Documents\KeyShot\Scripts"/>
                     </elseActionList>
                 </if>
             </elseActionList>
         </if>
-        <if>
-            <conditionRuleList>
-                <compareText>
-                    <text>${keyshot_resources_directory}</text>
-                    <logic>does_not_equal</logic>
-                    <value></value>
-                </compareText>
-            </conditionRuleList>
-            <actionList>
-                <setInstallerVariable name="keyshot_scripts_directory" value="${keyshot_resources_directory}\Scripts"/>
-            </actionList>
-            <elseActionList>
-                <setInstallerVariable name="keyshot_scripts_directory" value=""/>
-            </elseActionList>
-        </if>
+        <createDirectory>
+            <path>${keyshot_scripts_directory}</path>
+        </createDirectory>
     </initializationActionList>
     <parameterList>
         <stringParameter name="deadline_cloud_for_keyshot_summary" ask="0" cliOptionShow="0">

--- a/install_builder/deadline-cloud-for-keyshot.xml
+++ b/install_builder/deadline-cloud-for-keyshot.xml
@@ -96,7 +96,7 @@
             <allowEmptyValue>0</allowEmptyValue>
             <ask>yes</ask>
             <cliOptionName>keyshot-scripts-directory</cliOptionName>
-            <cliOptionText>Path to scripts directory in the KeyShot resources directory. The default value is detected from the KEYSHOT or KEYSHOT12 environment variables if present.</cliOptionText>
+            <cliOptionText>Path to scripts directory in the KeyShot resources directory. When the installer is run, if a KEYSHOT or KEYSHOT12 environment variable is present and valid, this directory will default to the detected Scripts folder.</cliOptionText>
             <mustBeWritable>yes</mustBeWritable>
             <mustExist>1</mustExist>
         </directoryParameter>

--- a/install_builder/deadline-cloud-for-keyshot.xml
+++ b/install_builder/deadline-cloud-for-keyshot.xml
@@ -66,7 +66,7 @@
                     </conditionRuleList>
                     <actionList>
                         <!-- KeyShot 2023 env var -->
-                        <setInstallerVariable name="keyshot_scripts_directory_default" value="${env(KEYSHOT12)}\Scripts"/>
+                        <setInstallerVariable name="keyshot_scripts_directory" value="${env(KEYSHOT12)}\Scripts"/>
                     </actionList>
                     <elseActionList>
                         <setInstallerVariable name="keyshot_scripts_directory" value=""/>
@@ -96,7 +96,7 @@
             <allowEmptyValue>0</allowEmptyValue>
             <ask>yes</ask>
             <cliOptionName>keyshot-scripts-directory</cliOptionName>
-            <cliOptionText>Path to scripts directory in the KeyShot resources directory. For easiest installation, KeyShot should be installed before installing Deadline Cloud for KeyShot.</cliOptionText>
+            <cliOptionText>Path to scripts directory in the KeyShot resources directory. The default value is detected from the KEYSHOT or KEYSHOT12 environment variables if present.</cliOptionText>
             <mustBeWritable>yes</mustBeWritable>
             <mustExist>1</mustExist>
         </directoryParameter>

--- a/install_builder/deadline-cloud-for-keyshot.xml
+++ b/install_builder/deadline-cloud-for-keyshot.xml
@@ -66,18 +66,22 @@
                     </conditionRuleList>
                     <actionList>
                         <!-- KeyShot 2023 env var -->
-                        <setInstallerVariable name="keyshot_scripts_directory" value="${env(KEYSHOT12)}\Scripts"/>
+                        <setInstallerVariable name="keyshot_scripts_directory_default" value="${env(KEYSHOT12)}\Scripts"/>
                     </actionList>
                     <elseActionList>
-                        <!-- KeyShot 2024 default location as a fallback -->
-                        <setInstallerVariable name="keyshot_scripts_directory" value="${user_home_directory}\Documents\KeyShot\Scripts"/>
+                        <setInstallerVariable name="keyshot_scripts_directory" value=""/>
                     </elseActionList>
                 </if>
             </elseActionList>
         </if>
-        <createDirectory>
-            <path>${keyshot_scripts_directory}</path>
-        </createDirectory>
+        <if>
+            <conditionRuleList>
+                <fileExists negate="1" path="${keyshot_scripts_directory}"/>
+            </conditionRuleList>
+            <actionList>
+                <setInstallerVariable name="keyshot_scripts_directory" value=""/>
+            </actionList>
+        </if>
     </initializationActionList>
     <parameterList>
         <stringParameter name="deadline_cloud_for_keyshot_summary" ask="0" cliOptionShow="0">
@@ -90,7 +94,6 @@
             <description>KeyShot Scripts Directory</description>
             <explanation>Path to scripts directory in the KeyShot resources directory. For easiest installation, KeyShot should be installed before installing Deadline Cloud for KeyShot.</explanation>
             <allowEmptyValue>0</allowEmptyValue>
-            <default>Will be detected from the KEYSHOT or KEYSHOT12 environment variables during installation. If neither exists and the KeyShot component is enabled, this must be input.</default>
             <ask>yes</ask>
             <cliOptionName>keyshot-scripts-directory</cliOptionName>
             <cliOptionText>Path to scripts directory in the KeyShot resources directory. For easiest installation, KeyShot should be installed before installing Deadline Cloud for KeyShot.</cliOptionText>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The KeyShot installer didn't install the submitter script in some circumstances. Specifically, I had a KeyShot install where the KeyShot resources folder pointed to a directory that did not yet exist.

### What was the solution? (How)
- Create the scripts directory if it doesn't exist already
- Use a fallback value for the scripts directory if one cannot be found from environment variables (e.g. if someone runs the Deadline installer before running the KeyShot installer)

### What is the impact of this change?
KeyShot installer works in more cases.

### How was this change tested?
I ran the installer with KeyShot was installed and without, and in both cases it installed the plugin correctly.

### Was this change documented?
Not needed

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*