### PR TITLE
fix: downgrade python-semantic-release to fix changelog

### DIFF
--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,1 +1,1 @@
-python-semantic-release == 9.11.*
+python-semantic-release == 9.9.*


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
python-semantic-release 9.11 seems to break the changelog generation.

### What was the solution? (How)
Downgrade to 9.9 which was working.

### What is the impact of this change?
Fixes changelog generation.

### How was this change tested?
9.9 previously worked.

### Was this change documented?
Not needed

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*