### PR TITLE
chore: Upgrade deadline-cloud to 0.49.0.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline >= 0.48.9,< 0.49",
+    "deadline >= 0.49.0,< 0.50",
     "openjd-adaptor-runtime >= 0.7,< 0.9",
 ]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

A new version of `deadline-cloud` was released.

### What was the solution? (How)

Updated the `deadline-cloud` dependency to `>=0.49.0, <0.50`

### What is the impact of this change?

Consume new changes and stay up to date.

### How was this change tested?

Built locally and ran integration tests.

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*