### PR TITLE
fix!: use only Windows workers by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ AWS Deadline Cloud for KeyShot is a python package that allows users to create [
 This library requires:
 1. KeyShot 2023 or 2024
 1. Python 3.9 or higher; and
-1. Windows or macOS operating system.
+1. Windows or macOS operating system for job submission and Windows operating system for job rendering
 
 ## Submitter
 

--- a/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
+++ b/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
@@ -166,6 +166,9 @@ def construct_job_template(filename: str) -> dict:
         "steps": [
             {
                 "name": "Render",
+                "hostRequirements": {
+                    "attributes": [{"name": "attr.worker.os.family", "anyOf": ["windows"]}]
+                },
                 "parameterSpace": {
                     "taskParameterDefinitions": [
                         {"name": "Frame", "type": "INT", "range": "{{Param.Frames}}"}


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Currently, Keyshot is only supported for Windows on AWS Deadline Cloud. However, Linux workers were being assigned to Keyshot renders by default, causing jobs to fail unexpectedly.

### What was the solution? (How)
By default, generated Keyshot templates have been configured to only use Windows workers for rendering. This will be used in most customers' workflows.

### What is the impact of this change?
This will help customers avoid having work picked up by Linux fleets, which most customers will not have setup to work with Keyshot.

### How was this change tested?
1. Submitted a job from Keyshot with the updated script
2. Confirmed that the Windows worker requirement was in the Deadline bundle history.
3. Confirmed that the work was picked up by a Windows worker.

### Was this change documented?
Yup!

### Is this a breaking change?
Yes, this is a breaking change, although we do not think any customers will be affected by it due to current lack of support for Keyshot Linux/Mac renders on AWS Deadline Cloud. 

If a customer wishes to use Linux renders, they can change the "windows" `attr.worker.os.family` in `Submit to AWS Deadline Cloud` to `linux` or `mac`. If they wish to use any operating system, they can remove the `hostRequirements` section entirely.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

BREAKING CHANGE