### PR TITLE
fix!: use keyshot-openjd in submitter

### DIFF
--- a/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
+++ b/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
@@ -193,7 +193,7 @@ def construct_job_template(filename: str) -> dict:
                             ],
                             "actions": {
                                 "onEnter": {
-                                    "command": "KeyShotAdaptor",
+                                    "command": "keyshot-openjd",
                                     "args": [
                                         "daemon",
                                         "start",
@@ -207,7 +207,7 @@ def construct_job_template(filename: str) -> dict:
                                     "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
                                 },
                                 "onExit": {
-                                    "command": "KeyShotAdaptor",
+                                    "command": "keyshot-openjd",
                                     "args": [
                                         "daemon",
                                         "stop",
@@ -231,7 +231,7 @@ def construct_job_template(filename: str) -> dict:
                     ],
                     "actions": {
                         "onRun": {
-                            "command": "KeyShotAdaptor",
+                            "command": "keyshot-openjd",
                             "args": [
                                 "daemon",
                                 "run",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We currently use `KeyshotAdaptor` as the entry point to running Keyshot on Windows by default. The `KeyshotAdaptor` entry point is deprecated in favour of `keyshot-openjd` ([code link](https://github.com/aws-deadline/deadline-cloud-for-keyshot/blob/ca50175bace3d2c2ee2d97e653100b81a77d43af/pyproject.toml#L42))

### What was the solution? (How)
Updated the template to use `keyshot-openjd` instead of `KeyshotAdaptor`

### What is the impact of this change?
Removal of deprecated code.

### How was this change tested?
Submitted a job against an updated Keyshot Conda package which supported `keyshot-openjd`. Confirmed that the job ran successfully.

Also ran `hatch clean && hatch build && hatch run fmt && hatch run lint && hatch run test`

### Was this change documented?
No, N/A

### Is this a breaking change?
Yes. This uses a different entry point to the Keyshot adaptor than previous revisions. If customers wish to continue to use `KeyshotAdaptor`, they can update references to `keyshot-openjd` in `Submit to AWS Deadline Cloud` back to `KeyShotAdaptor`.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*