### PR TITLE
chore: update installer component description to be consistent with other components

### DIFF
--- a/install_builder/deadline-cloud-for-keyshot.xml
+++ b/install_builder/deadline-cloud-for-keyshot.xml
@@ -1,6 +1,6 @@
 <component>
     <name>deadline_cloud_for_keyshot</name>
-    <description>Deadline Cloud for KeyShot 2023/2024</description>
+    <description>Deadline Cloud for KeyShot 2023-2024</description>
     <detailedDescription>KeyShot plugin for submitting jobs to AWS Deadline Cloud.</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Noticed that the KeyShot installer was inconsistent with other components for how it shows its versions. All other components use the format A-B, but KeyShot used A/B. Other components with only 2 versions also used A-B formatting.

### What was the solution? (How)
Updated it to A-B formatting.

### What is the impact of this change?
Consistency and readability in the installer.

### How was this change tested?
Rebuilt the installer locally.

![image](https://github.com/user-attachments/assets/c61adea0-2ce6-4c28-9f7f-417fd1205260)

### Was this change documented?
No, N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*