### PR TITLE
fix: pause rendering while submitting

### DIFF
--- a/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
+++ b/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
@@ -457,103 +457,104 @@ def get_ksp_bundle_files(directory: str) -> Tuple[str, list[str]]:
 
 def main(lux):
     if lux.isPaused():
-        should_unpause_on_finish = False
+        # If rendering is already paused, run the function normally
+        main_inner(lux)
     else:
-        should_unpause_on_finish = True
-        lux.pause()
+        # If render is not already paused, pause while running then resume
+        try:
+            lux.pause()
+            main_inner(lux)
+        finally:
+            lux.unpause()
 
-    try:
-        if lux.isSceneChanged():
-            result = lux.getInputDialog(
-                title="Unsaved changes",
-                values=[
-                    (lux.DIALOG_LABEL, "You have unsaved changes. Do you want to save your file?")
-                ],
-            )
-            # result is {} if the user clicks Ok and None if the user clicks cancel
-            if result is None:
-                # Raise an exception so Keyshot shows the script's result status as "Failure" instead of "Success"
-                raise Exception("Changes must be saved before submitting.")
-            else:
-                lux.saveFile()
 
-        dialog_selections = options_dialog()
+def main_inner(lux):
+    if lux.isSceneChanged():
+        result = lux.getInputDialog(
+            title="Unsaved changes",
+            values=[(lux.DIALOG_LABEL, "You have unsaved changes. Do you want to save your file?")],
+        )
+        # result is {} if the user clicks Ok and None if the user clicks cancel
+        if result is None:
+            # Raise an exception so Keyshot shows the script's result status as "Failure" instead of "Success"
+            raise Exception("Changes must be saved before submitting.")
+        else:
+            lux.saveFile()
 
-        if not dialog_selections:
-            # Dialog was canceled. Raise an exception so Keyshot does not show the script's result status as "Success"
+    dialog_selections = options_dialog()
+
+    if not dialog_selections:
+        # Dialog was canceled. Raise an exception so Keyshot does not show the script's result status as "Success"
+        raise Exception("Submission was canceled.")
+
+    scene_info = lux.getSceneInfo()
+    scene_file = scene_info["file"]
+    scene_name, _ = os.path.splitext(scene_info["name"])
+    current_frame = lux.getAnimationFrame()
+    frame_count = lux.getAnimationInfo().get("frames")
+
+    settings = Settings(
+        parameter_values=[
+            {
+                "name": "Frames",
+                "value": f"1-{frame_count}" if frame_count else f"{current_frame}",
+            },
+            {
+                "name": "OutputFilePath",
+                "value": os.path.join(os.path.dirname(scene_file), f"{scene_name}.%d.png"),
+            },
+            {
+                "name": "OutputFormat",
+                "value": "PNG",
+            },
+        ],
+        input_filenames=[],
+        auto_detected_input_filenames=[],
+        input_directories=[],
+        output_directories=[],
+        referenced_paths=[],
+    )
+
+    sticky_settings = load_sticky_settings(scene_file)
+    if sticky_settings:
+        settings.apply_sticky_settings(sticky_settings)
+
+    with tempfile.TemporaryDirectory() as bundle_temp_dir:
+        # {'submission_mode': [0, 'the scene BIP file and all external files references']}
+        if not dialog_selections[SUBMISSION_MODE_KEY][0]:
+            temp_scene_file, input_filenames = get_ksp_bundle_files(bundle_temp_dir)
+            settings.auto_detected_input_filenames = input_filenames
+            settings.parameter_values.append({"name": "KeyShotFile", "value": temp_scene_file})
+        else:
+            settings.parameter_values.append({"name": "KeyShotFile", "value": scene_file})
+
+        # Add default values for Conda
+        major_version, minor_version = lux.getKeyShotDisplayVersion()
+        settings.parameter_values.append(
+            {
+                "name": "CondaPackages",
+                "value": f"keyshot={major_version}.* keyshot-openjd=0.3.*",
+            }
+        )
+        settings.parameter_values.append({"name": "CondaChannels", "value": "deadline-cloud"})
+
+        job_template = construct_job_template(scene_name)
+        asset_references = construct_asset_references(settings)
+        parameter_values = construct_parameter_values(settings)
+
+        dump_json_to_dir(job_template, bundle_temp_dir, "template.json")
+        dump_json_to_dir(asset_references, bundle_temp_dir, "asset_references.json")
+        dump_json_to_dir(parameter_values, bundle_temp_dir, "parameter_values.json")
+
+        output = gui_submit(bundle_temp_dir)
+
+    if output:
+        if output.get("status") == "CANCELED":
+            # Raise an exception so Keyshot does not show the script's result status as "Success"
             raise Exception("Submission was canceled.")
 
-        scene_info = lux.getSceneInfo()
-        scene_file = scene_info["file"]
-        scene_name, _ = os.path.splitext(scene_info["name"])
-        current_frame = lux.getAnimationFrame()
-        frame_count = lux.getAnimationInfo().get("frames")
-
-        settings = Settings(
-            parameter_values=[
-                {
-                    "name": "Frames",
-                    "value": f"1-{frame_count}" if frame_count else f"{current_frame}",
-                },
-                {
-                    "name": "OutputFilePath",
-                    "value": os.path.join(os.path.dirname(scene_file), f"{scene_name}.%d.png"),
-                },
-                {
-                    "name": "OutputFormat",
-                    "value": "PNG",
-                },
-            ],
-            input_filenames=[],
-            auto_detected_input_filenames=[],
-            input_directories=[],
-            output_directories=[],
-            referenced_paths=[],
-        )
-
-        sticky_settings = load_sticky_settings(scene_file)
-        if sticky_settings:
-            settings.apply_sticky_settings(sticky_settings)
-
-        with tempfile.TemporaryDirectory() as bundle_temp_dir:
-            # {'submission_mode': [0, 'the scene BIP file and all external files references']}
-            if not dialog_selections[SUBMISSION_MODE_KEY][0]:
-                temp_scene_file, input_filenames = get_ksp_bundle_files(bundle_temp_dir)
-                settings.auto_detected_input_filenames = input_filenames
-                settings.parameter_values.append({"name": "KeyShotFile", "value": temp_scene_file})
-            else:
-                settings.parameter_values.append({"name": "KeyShotFile", "value": scene_file})
-
-            # Add default values for Conda
-            major_version, minor_version = lux.getKeyShotDisplayVersion()
-            settings.parameter_values.append(
-                {
-                    "name": "CondaPackages",
-                    "value": f"keyshot={major_version}.* keyshot-openjd=0.3.*",
-                }
-            )
-            settings.parameter_values.append({"name": "CondaChannels", "value": "deadline-cloud"})
-
-            job_template = construct_job_template(scene_name)
-            asset_references = construct_asset_references(settings)
-            parameter_values = construct_parameter_values(settings)
-
-            dump_json_to_dir(job_template, bundle_temp_dir, "template.json")
-            dump_json_to_dir(asset_references, bundle_temp_dir, "asset_references.json")
-            dump_json_to_dir(parameter_values, bundle_temp_dir, "parameter_values.json")
-
-            output = gui_submit(bundle_temp_dir)
-
-        if output:
-            if output.get("status") == "CANCELED":
-                # Raise an exception so Keyshot does not show the script's result status as "Success"
-                raise Exception("Submission was canceled.")
-
-            settings.apply_submitter_settings(output)
-            save_sticky_settings(scene_file, settings)
-    finally:
-        if should_unpause_on_finish:
-            lux.unpause()
+        settings.apply_submitter_settings(output)
+        save_sticky_settings(scene_file, settings)
 
 
 if __name__ == "__main__":

--- a/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
+++ b/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
@@ -456,89 +456,104 @@ def get_ksp_bundle_files(directory: str) -> Tuple[str, list[str]]:
 
 
 def main(lux):
-    if lux.isSceneChanged():
-        result = lux.getInputDialog(
-            title="Unsaved changes",
-            values=[(lux.DIALOG_LABEL, "You have unsaved changes. Do you want to save your file?")],
-        )
-        # result is {} if the user clicks Ok and None if the user clicks cancel
-        if result is None:
-            # Raise an exception so Keyshot shows the script's result status as "Failure" instead of "Success"
-            raise Exception("Changes must be saved before submitting.")
-        else:
-            lux.saveFile()
+    if lux.isPaused():
+        should_unpause_on_finish = False
+    else:
+        should_unpause_on_finish = True
+        lux.pause()
 
-    dialog_selections = options_dialog()
+    try:
+        if lux.isSceneChanged():
+            result = lux.getInputDialog(
+                title="Unsaved changes",
+                values=[
+                    (lux.DIALOG_LABEL, "You have unsaved changes. Do you want to save your file?")
+                ],
+            )
+            # result is {} if the user clicks Ok and None if the user clicks cancel
+            if result is None:
+                # Raise an exception so Keyshot shows the script's result status as "Failure" instead of "Success"
+                raise Exception("Changes must be saved before submitting.")
+            else:
+                lux.saveFile()
 
-    if not dialog_selections:
-        # Dialog was canceled. Raise an exception so Keyshot does not show the script's result status as "Success"
-        raise Exception("Submission was canceled.")
+        dialog_selections = options_dialog()
 
-    scene_info = lux.getSceneInfo()
-    scene_file = scene_info["file"]
-    scene_name, _ = os.path.splitext(scene_info["name"])
-    current_frame = lux.getAnimationFrame()
-    frame_count = lux.getAnimationInfo().get("frames")
-
-    settings = Settings(
-        parameter_values=[
-            {
-                "name": "Frames",
-                "value": f"1-{frame_count}" if frame_count else f"{current_frame}",
-            },
-            {
-                "name": "OutputFilePath",
-                "value": os.path.join(os.path.dirname(scene_file), f"{scene_name}.%d.png"),
-            },
-            {
-                "name": "OutputFormat",
-                "value": "PNG",
-            },
-        ],
-        input_filenames=[],
-        auto_detected_input_filenames=[],
-        input_directories=[],
-        output_directories=[],
-        referenced_paths=[],
-    )
-
-    sticky_settings = load_sticky_settings(scene_file)
-    if sticky_settings:
-        settings.apply_sticky_settings(sticky_settings)
-
-    with tempfile.TemporaryDirectory() as bundle_temp_dir:
-        # {'submission_mode': [0, 'the scene BIP file and all external files references']}
-        if not dialog_selections[SUBMISSION_MODE_KEY][0]:
-            temp_scene_file, input_filenames = get_ksp_bundle_files(bundle_temp_dir)
-            settings.auto_detected_input_filenames = input_filenames
-            settings.parameter_values.append({"name": "KeyShotFile", "value": temp_scene_file})
-        else:
-            settings.parameter_values.append({"name": "KeyShotFile", "value": scene_file})
-
-        # Add default values for Conda
-        major_version, minor_version = lux.getKeyShotDisplayVersion()
-        settings.parameter_values.append(
-            {"name": "CondaPackages", "value": f"keyshot={major_version}.* keyshot-openjd=0.3.*"}
-        )
-        settings.parameter_values.append({"name": "CondaChannels", "value": "deadline-cloud"})
-
-        job_template = construct_job_template(scene_name)
-        asset_references = construct_asset_references(settings)
-        parameter_values = construct_parameter_values(settings)
-
-        dump_json_to_dir(job_template, bundle_temp_dir, "template.json")
-        dump_json_to_dir(asset_references, bundle_temp_dir, "asset_references.json")
-        dump_json_to_dir(parameter_values, bundle_temp_dir, "parameter_values.json")
-
-        output = gui_submit(bundle_temp_dir)
-
-    if output:
-        if output.get("status") == "CANCELED":
-            # Raise an exception so Keyshot does not show the script's result status as "Success"
+        if not dialog_selections:
+            # Dialog was canceled. Raise an exception so Keyshot does not show the script's result status as "Success"
             raise Exception("Submission was canceled.")
 
-        settings.apply_submitter_settings(output)
-        save_sticky_settings(scene_file, settings)
+        scene_info = lux.getSceneInfo()
+        scene_file = scene_info["file"]
+        scene_name, _ = os.path.splitext(scene_info["name"])
+        current_frame = lux.getAnimationFrame()
+        frame_count = lux.getAnimationInfo().get("frames")
+
+        settings = Settings(
+            parameter_values=[
+                {
+                    "name": "Frames",
+                    "value": f"1-{frame_count}" if frame_count else f"{current_frame}",
+                },
+                {
+                    "name": "OutputFilePath",
+                    "value": os.path.join(os.path.dirname(scene_file), f"{scene_name}.%d.png"),
+                },
+                {
+                    "name": "OutputFormat",
+                    "value": "PNG",
+                },
+            ],
+            input_filenames=[],
+            auto_detected_input_filenames=[],
+            input_directories=[],
+            output_directories=[],
+            referenced_paths=[],
+        )
+
+        sticky_settings = load_sticky_settings(scene_file)
+        if sticky_settings:
+            settings.apply_sticky_settings(sticky_settings)
+
+        with tempfile.TemporaryDirectory() as bundle_temp_dir:
+            # {'submission_mode': [0, 'the scene BIP file and all external files references']}
+            if not dialog_selections[SUBMISSION_MODE_KEY][0]:
+                temp_scene_file, input_filenames = get_ksp_bundle_files(bundle_temp_dir)
+                settings.auto_detected_input_filenames = input_filenames
+                settings.parameter_values.append({"name": "KeyShotFile", "value": temp_scene_file})
+            else:
+                settings.parameter_values.append({"name": "KeyShotFile", "value": scene_file})
+
+            # Add default values for Conda
+            major_version, minor_version = lux.getKeyShotDisplayVersion()
+            settings.parameter_values.append(
+                {
+                    "name": "CondaPackages",
+                    "value": f"keyshot={major_version}.* keyshot-openjd=0.3.*",
+                }
+            )
+            settings.parameter_values.append({"name": "CondaChannels", "value": "deadline-cloud"})
+
+            job_template = construct_job_template(scene_name)
+            asset_references = construct_asset_references(settings)
+            parameter_values = construct_parameter_values(settings)
+
+            dump_json_to_dir(job_template, bundle_temp_dir, "template.json")
+            dump_json_to_dir(asset_references, bundle_temp_dir, "asset_references.json")
+            dump_json_to_dir(parameter_values, bundle_temp_dir, "parameter_values.json")
+
+            output = gui_submit(bundle_temp_dir)
+
+        if output:
+            if output.get("status") == "CANCELED":
+                # Raise an exception so Keyshot does not show the script's result status as "Success"
+                raise Exception("Submission was canceled.")
+
+            settings.apply_submitter_settings(output)
+            save_sticky_settings(scene_file, settings)
+    finally:
+        if should_unpause_on_finish:
+            lux.unpause()
 
 
 if __name__ == "__main__":

--- a/test/keyshot_submitter/test_keyshot_submitter.py
+++ b/test/keyshot_submitter/test_keyshot_submitter.py
@@ -264,6 +264,28 @@ def test_unsaved_changes_prompt():
     local_mock_lux.saveFile.assert_called()
 
 
+def test_auto_pause_resume():
+    local_mock_lux = mock.Mock()
+    local_mock_lux.isPaused = mock.Mock()
+    local_mock_lux.pause = mock.Mock()
+    local_mock_lux.unpause = mock.Mock()
+
+    # Throw an exception to cut the submitter short
+    local_mock_lux.isSceneChanged.side_effect = Exception()
+
+    local_mock_lux.isPaused.return_value = True
+    with pytest.raises(Exception):
+        submitter.main(local_mock_lux)
+    local_mock_lux.pause.assert_not_called()
+    local_mock_lux.unpause.assert_not_called()
+
+    local_mock_lux.isPaused.return_value = False
+    with pytest.raises(Exception):
+        submitter.main(local_mock_lux)
+    local_mock_lux.pause.assert_called()
+    local_mock_lux.unpause.assert_called()
+
+
 def test_save_ksp_bundle():
     dir = os.path.normpath("/testdir/test")
     bundle_name = "test_bundle.ksp"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
If KeyShot is rendering while the submitter opens, the workstation can slow down or crash.

Fixes: https://github.com/aws-deadline/deadline-cloud-for-keyshot/issues/158
### What was the solution? (How)
Pause rendering while submitting.

### What is the impact of this change?
Avoids slowdowns and crashes.

### How was this change tested?
Manually opening the submitter and watching it pause and resume rendering. Also unit tests.

### Was this change documented?
Not needed.

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*