### PR TITLE
chore: Removed encoding specification when opening pyproject.toml

### DIFF
--- a/scripts/_project.py
+++ b/scripts/_project.py
@@ -24,9 +24,7 @@ def get_project_dict(project_path: Optional[Path] = None) -> dict[str, Any]:
 
         mode = "rb"
 
-    with open(
-        str((project_path or get_git_root()) / "pyproject.toml"), mode, encoding="utf-8"
-    ) as pyproject_toml:
+    with open(str((project_path or get_git_root()) / "pyproject.toml"), mode) as pyproject_toml:
         return toml.load(pyproject_toml)
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
You cannot specify an encoding when opening a binary file in Python. In Python 3.11+ we are using the built in tomllib in the python standard library which requires opening the file in binary mode. For all code paths we were explicitly specifying the file encoding, however, this does not work for binary mode, so the script was failing if Python 3.11+ was used to run it. 

### What was the solution? (How)

Just don't specify the encoding when opening the file. It's not important here as we control the pyproject.toml file.

### What is the impact of this change?

We will be able to generate the deps bundle using Python 3.11+ again.

### How was this change tested?
```py
Python 3.11.11 (main, Dec  3 2024, 17:20:40) [GCC 14.2.1 20241116] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import scripts._project
>>> scripts._project.get_project_dict()
{'build-system': {'requires': ['hatchling', 'hatch-vcs'], 'build-backend': 'hatchling.build'}, 'project': {'name': 'deadline-cloud-for-keyshot', 'description': 'AWS Deadline Cloud for KeyShot', 'authors': [{'name': 'Amazon Web Services'}], 'dynamic': ['version'], 'readme': 'README.md', 'license': 'Apache-2.0', 'requires-python': '>=3.9', 'classifiers': ['Development Status :: 5 - Production/Stable', 'Programming Language :: Python', 'Programming Language :: Python :: 3 :: Only', 'Programming Language :: Python :: 3.9', 'Programming Language :: Python :: 3.10', 'Programming Language :: Python :: 3.11', 'Programming Language :: Python :: 3.12', 'Operating System :: Microsoft :: Windows', 'Operating System :: MacOS', 'License :: OSI Approved :: Apache Software License', 'Intended Audience :: Developers', 'Intended Audience :: End Users/Desktop'], 'dependencies': ['deadline >= 0.48.9,< 0.50', 'openjd-adaptor-runtime >= 0.7,< 0.10'], 'urls': {'Homepage': 'https://github.com/aws-deadline/deadline-cloud-for-keyshot', 'Source': 'https://github.com/aws-deadline/deadline-cloud-for-keyshot'}, 'scripts': {'keyshot-openjd': 'deadline.keyshot_adaptor.KeyShotAdaptor:main', 'KeyShotAdaptor': 'deadline.keyshot_adaptor.KeyShotAdaptor:main'}}, 'tool': {'hatch': {'build': {'artifacts': ['*_version.py'], 'hooks': {'vcs': {'version-file': '_version.py'}, 'custom': {'path': 'hatch_custom_hook.py', 'copy_version_py': {'destinations': ['src/deadline/keyshot_adaptor', 'src/deadline/keyshot_submitter']}}}, 'targets': {'sdist': {'include': ['src/*', 'hatch_version_hook.py']}, 'wheel': {'packages': ['src/deadline']}}}, 'version': {'source': 'vcs', 'raw-options': {'version_scheme': 'post-release'}}}, 'mypy': {'check_untyped_defs': True, 'show_error_codes': True, 'pretty': True, 'namespace_packages': True, 'explicit_package_bases': True, 'mypy_path': 'src', 'overrides': [{'module': ['lux.*', 'qtpy.*'], 'ignore_missing_imports': True}]}, 'ruff': {'line-length': 100, 'lint': {'ignore': ['E501'], 'isort': {'known-first-party': ['deadline', 'openjd']}}}, 'black': {'line-length': 100}, 'pytest': {'ini_options': {'xfail_strict': True, 'addopts': ['--durations=5', '--color=yes', '--cov=src/deadline/keyshot_adaptor', '--cov=src/deadline/keyshot_submitter', '--cov-report=html:build/coverage', '--cov-report=xml:build/coverage/coverage.xml', '--cov-report=term-missing', '--numprocesses=auto'], 'testpaths': ['test'], 'looponfailroots': ['src', 'test'], 'filterwarnings': ['ignore::DeprecationWarning']}}, 'coverage': {'run': {'source_pkgs': ['deadline/keyshot_submitter', 'deadline/keyshot_adaptor'], 'branch': True, 'parallel': True, 'omit': ['**/__main__.py', '**/_version.py']}, 'paths': {'source': ['src/']}, 'report': {'show_missing': True, 'fail_under': 18}}, 'semantic_release': {'major_on_zero': False, 'tag_format': '{version}', 'commit_parser_options': {'allowed_tags': ['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'style', 'refactor', 'test'], 'minor_tags': [], 'patch_tags': ['chore', 'feat', 'fix', 'refactor']}, 'publish': {'upload_to_vcs_release': False}, 'changelog': {'template_dir': '.semantic_release', 'environment': {'trim_blocks': True, 'lstrip_blocks': True}}, 'branches': {'release': {'match': '(mainline|release)'}}}}}
```

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*