### PR TITLE
docs: add note about KeyShot 2023 jobs on SMF

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ This library requires:
 1. Python 3.9 or higher; and
 1. Windows or macOS operating system for job submission and Windows operating system for job rendering
 
+> [!NOTE]  
+> Deadline Cloud service-mangaged fleets have built-in access to KeyShot 2024 only. When submitting a job from KeyShot 2023, you can still render your job on KeyShot 2024 by updating the "Conda Packages" field in the submitter specify `keyshot=2024.*`.
+
 ## Submitter
 
 This package provides a KeyShot plugin script that creates jobs for AWS Deadline Cloud using the [AWS Deadline Cloud client library][deadline-cloud-client]. Based on the loaded scene it determines the files required, allows the user to specify render options with KeyShot's render interface, and builds an [OpenJD template][openjd] that defines the workflow.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This library requires:
 1. Windows or macOS operating system for job submission and Windows operating system for job rendering
 
 > [!NOTE]  
-> Deadline Cloud service-mangaged fleets have built-in access to KeyShot 2024 only. When submitting a job from KeyShot 2023, you can still render your job on KeyShot 2024 by updating the "Conda Packages" field in the submitter specify `keyshot=2024.*`.
+> Deadline Cloud service-managed fleets have built-in support for KeyShot 2024 only. When submitting a job from KeyShot 2023, you can still render your job on KeyShot 2024 by updating the "Conda Packages" field in the submitter specify `keyshot=2024.*`.
 
 ## Submitter
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Jobs fail to run on SMF when rendering from KeyShot 2023 because the KeyShot conda package version is defaulted to match the workstation, but SMF does not include KeyShot 2023.

Fixes: https://github.com/aws-deadline/deadline-cloud-for-keyshot/issues/135

### What was the solution? (How)
Add a note to the docs.

### What is the impact of this change?
The compatibility issue and workaround are visible.

### How was this change tested?
Inspected the docs.

### Was this change documented?
Yes

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*