### PR TITLE
docs: update a few changes to the pull request template and README

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,9 +15,6 @@ Fixes: *<insert link to GitHub issue here>*
 *delete text starting here*
 See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud-for-keyshot/blob/mainline/DEVELOPMENT.md) for information on running tests.
 
-- Have you run the unit tests?
-*delete text ending here*
-
 ### Was this change documented?
 
 *delete text starting here*

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ set up, we strongly recommend that you construct a simple test scene that can be
 
 ## Submitter
 
-The KeyShot submitter extension creates a button in KeyShot (`Window` > `Scripting Console` > `Scripts` > `Submit to AWS Deadline Cloud` > `Run`) that can be used to submit jobs to Deadline Cloud. Clicking this button reveals an interface to submit a job to Deadline Cloud.
+The KeyShot submitter extension creates a runnable script in KeyShot (`Window` > `Scripting Console` > `Scripts` > `Submit to AWS Deadline Cloud` > `Run`) that can be used to submit jobs to Deadline Cloud. Using this script reveals an interface to submit a job to Deadline Cloud.
 It automatically determines the files required based on the loaded scene, allows the user to specify render options, builds an
 [Open Job Description template][openjd] that defines the workflow, and submits the job to the farm and queue of your choosing.
 


### PR DESCRIPTION
Addressed a few comments from https://github.com/aws-deadline/deadline-cloud-for-keyshot/pull/164

Unit tests are automatically run by our GitHub actions, so we don't need to add a note in our pull request template for them. Also reworded the description of the KeyShot submitter extension from `button` -> `runnable script`

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
