### PR TITLE
chore: fix missing link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ AWS Deadline Cloud for KeyShot is a python package that allows users to create [
 [deadline-cloud-submitter]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/submitter.html
 [deadline-cloud-monitor]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/monitor-onboarding.html
 [usage-based-licensing]: https://aws.amazon.com/deadline-cloud/features/
+[service-managed-fleets]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/smf-manage.html
 
 ## Compatibility
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Noticed there was a missing link for service-managed-fleets which was causing the link to show up as 

> **[service-managed fleets][service-managed-fleets]**

### What was the solution? (How)

Add a link for `[service-managed-fleets]` so that it resolves

### What is the impact of this change?

Less mistakes in our README


### How was this change tested?

Confirmed in the markdown rendering on GitHub that the link renders properly

You can see the rich diff here: https://github.com/aws-deadline/deadline-cloud-for-keyshot/pull/175/files?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
