### PR TITLE
chore: update pip install deadline[gui] instructions to be Mac-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For most setups, you will also want to install the [Deadline Cloud monitor][dead
 
 ### Manually installing the submitter
 
-1. Run `pip install deadline[gui]`
+1. Run `pip install "deadline[gui]"`
 2. Copy the file `deadline-cloud-for-keyshot/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py` to the KeyShot scripts folder for your OS:
     - Windows (choose one):
         - User scripts folder e.g. `%USERPROFILE%/Documents/KeyShot/Scripts`


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
On Mac, `pip install deadline[gui]` doesn't work in cases due to the way it handles square bracket characters (`[]`). Updated the docs to surround `deadline[gui]` with double quotes.

`pip install "deadline[gui]"` also works on Windows and Linux, so this is safe for all platforms.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
