### PR TITLE
test: make integ tests generalized to 2024+

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -181,9 +181,8 @@ keyshot-openjd daemon stop \
    1. `export KEYSHOT_EXECUTABLE=<keyshot_headless location>` on Linux and MacOS.
       1. Default in MacOS user installs: `/Applications/Keyshot.app/Contents/MacOS/bin/keyshot_headless`
 1. Ensure licensing is available on your machine for KeyShot
-1. Download [Python 3.11.9](https://www.python.org/downloads/release/python-3119/) and do a system install of it (C:\Program Files\Python311 on Windows)
-1. Open a `hatch shell` (paths won't resolve proeprly without this)
-1. Run `hatch run integ:test` in the shell
+1. Download [Python 3.11.9](https://www.python.org/downloads/release/python-3119/) and do a system install of it (C:\Program Files\Python311 on Windows). This is required because the KeyShot Python is missing some standard libraries used by the adaptor but will automatically pull them from the installed Python 3.11.
+1. Run `hatch run integ:test`
 
 #### Running the Adaptor on a Farm
 

--- a/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_client.py
+++ b/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_client.py
@@ -67,7 +67,7 @@ def main():
         raise OSError(
             "KeyShotClient cannot connect to the Adaptor because the server path defined by "
             "the environment variable KEYSHOT_ADAPTOR_SERVER_PATH does not exist. Got: "
-            f"{os.environ['KEYSHOT_ADAPTOR_SERVER_PATH']}"
+            f"{server_path}"
         )
 
     client = KeyShotClient(server_path)

--- a/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
+++ b/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
@@ -218,7 +218,7 @@ def construct_job_template(filename: str) -> dict:
                                 },
                             },
                         },
-                    }
+                    },
                 ],
                 "script": {
                     "embeddedFiles": [

--- a/test/integ/cube/expected_bundle/parameter_values.json
+++ b/test/integ/cube/expected_bundle/parameter_values.json
@@ -18,7 +18,7 @@
         },
         {
             "name": "CondaPackages",
-            "value": "keyshot=2023.* keyshot-openjd=0.3.*"
+            "value": "keyshot=2024.* keyshot-openjd=0.3.*"
         },
         {
             "name": "CondaChannels",

--- a/test/integ/helpers/test_runners.py
+++ b/test/integ/helpers/test_runners.py
@@ -74,8 +74,19 @@ def run_keyshot_adaptor_test(
     job_params.pop("CondaChannels", None)
     job_params.pop("CondaPackages", None)
 
-    os.environ["DEADLINE_CLOUD_PYTHONPATH"] = ";".join(
-        [str(Path(__file__).parent.parent.parent.parent / "src")]
+    paths_to_add_to_deadline_cloud_pythonpath = [
+        str(Path(__file__).parent.parent.parent.parent / "src"),  # deadline import
+    ]
+    if "VIRTUAL_ENV" in os.environ:
+        # VIRTUAL_ENV env var comes from hatch env
+        paths_to_add_to_deadline_cloud_pythonpath.append(
+            str(
+                Path(os.environ["VIRTUAL_ENV"]).parent / "integ" / "Lib" / "site-packages"
+            )  # openjd import
+        )
+
+    os.environ["DEADLINE_CLOUD_PYTHONPATH"] = os.pathsep.join(
+        paths_to_add_to_deadline_cloud_pythonpath
     )
 
     for step in template["steps"]:
@@ -161,6 +172,13 @@ def assert_expected_job_bundle_and_generated_job_bundle_are_equal(
             content1 = content1.replace("PATH_TO_BE_REPLACED", prefix_path)
             content1 = replace_backslashes(content1)
             content2 = replace_backslashes(content2)
+            if file == "parameter_values.json":
+                # generalize to all versions of KeyShot and the adaptor
+                content2 = re.sub(
+                    r"keyshot=202[3-9].\* keyshot-openjd=0.\d.\*",
+                    "keyshot=2024.* keyshot-openjd=0.3.*",
+                    content2,
+                )
 
             content1_loaded = json.loads(content1)
             content2_loaded = json.loads(content2)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Added some minor improvements to integration tests to allow them to be run with KeyShot 2024.1 or 2024.2. Also cleaned up some submitter/adaptor code.

### How was this change tested?
`hatch run integ:test` passes

### Was this change documented?
No, N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
