### PR TITLE
docs: publish user guide to GitHub pages

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,0 +1,33 @@
+name: Build and Deploy MkDocs
+
+on:
+  push:
+    branches:
+      - mainline
+    paths:
+      - 'docs/user_guide/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/mkdocs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs-material
+
+      - name: Build and deploy documentation
+        run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /dist
+/site
 *.egg-info/
 __pycache__/
 .coverage

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -192,5 +192,9 @@ with real jobs, then we recommend using a [customer-managed fleet](https://docs.
 for your testing. We recommend performing this style of test if you have made any modifications that might interact with Deadline Cloud's
 job attachments feature, or that could interact with path mapping in any way.
 
+## User guide
+
+The user guide is generated from the markdown files in `docs/user_guide` and published to GitHub pages. To view the renderd user guide locally, run `hatch run docs:serve` which will open the user guide in your browser.
+
 ## Relevant links
 - [Keyshot 2024 scripting documentation](https://media.keyshot.com/scripting/doc/2024.1/lux.html)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 AWS Deadline Cloud for KeyShot is a python package that allows users to create [AWS Deadline Cloud][deadline-cloud] jobs from within KeyShot. Using the [Open Job Description (OpenJD) Adaptor Runtime][openjd-adaptor-runtime] this package also provides a command line application that adapts KeyShot's command line interface to support the [OpenJD specification][openjd].
 
+For instructions on installing and using this integration, visit the [user guide](https://aws-deadline.github.io/deadline-cloud-for-keyshot).
+
 [deadline-cloud]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/what-is-deadline-cloud.html
 [deadline-cloud-client]: https://github.com/aws-deadline/deadline-cloud
 [openjd]: https://github.com/OpenJobDescription/openjd-specifications/wiki

--- a/docs/user_guide/extra.css
+++ b/docs/user_guide/extra.css
@@ -1,0 +1,4 @@
+[data-md-color-scheme='default'] {
+  --md-primary-fg-color: #ff9900;
+  --md-accent-fg-color: #ff9900;
+}

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -1,0 +1,12 @@
+# AWS Deadline Cloud for KeyShot Studio User Guide
+
+This guide provides step-by-step instructions for using AWS Deadline Cloud with KeyShot Studio to render your projects faster by distributing rendering tasks across multiple machines.
+
+![Screenshot showing Deadline Cloud's KeyShot submitter with KeyShot Studio running behind it](./images/main-screenshot.png)
+
+## What's Inside
+
+This user guide covers:
+
+- [Installation](installation.md) - How to install the KeyShot submitter
+- [Using the Submitter](using-submitter.md) - How to prepare and submit rendering jobs

--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -1,0 +1,27 @@
+# Installation
+
+## Requirements
+
+Before you begin, make sure you have:
+
+- A Windows or MacOS workstation
+- KeyShot Studio 2023 or 2024
+- [Deadline Cloud monitor](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/monitor-onboarding.html) installed
+- Access to an AWS Deadline Cloud farm with either
+    - a Windows service-managed fleet or
+    - a customer-managed fleet with KeyShot Studio, the KeyShot adapter, and licensing set up
+
+## Installing the submitter
+
+
+The KeyShot submitter extension allows you to submit jobs to Deadline Cloud directly from within KeyShot. To install the submitter,
+
+1. Download the [official Deadline Cloud submitter installer](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/submitter.html)
+2. Run the installer and follow the on-screen instructions
+3. Launch KeyShot after installation
+
+> Currently a submitter installer is only availble for Windows. See the [the developer README](../../README.md) for manual install instructions for Mac.
+
+
+## Updating the submitter
+To update the submitter to the latest version, download and run the latest submitter installer.

--- a/docs/user_guide/using-submitter.md
+++ b/docs/user_guide/using-submitter.md
@@ -1,58 +1,6 @@
-# AWS Deadline Cloud for KeyShot Studio User Guide
+# Using the Submitter
 
-This guide provides step-by-step instructions for using AWS Deadline Cloud with KeyShot Studio to render your projects faster by distributing rendering tasks across multiple machines.
-
-![Screenshot showing Deadline Cloud's KeyShot submitter with KeyShot Studio running behind it](./images/main-screenshot.png)
-
-## Table of Contents
-
-- [Overview](#overview)
-- [Requirements](#requirements)
-- [Installation](#installation)
-- [Using the Submitter](#using-the-submitter)
-  - [Preparing Your Scene](#preparing-your-scene)
-  - [Submitting a Job](#submitting-a-job)
-  - [Submission Options](#submission-options)
-  - [Render Settings](#render-settings)
-- [Monitoring Your Jobs](#monitoring-your-jobs)
-- [Getting Help](#getting-help)
-
-## Overview
-
-AWS Deadline Cloud for KeyShot Studio allows you to:
-
-- Submit KeyShot rendering jobs to AWS Deadline Cloud directly from within KeyShot Studio
-- Distribute rendering tasks across multiple machines
-- Monitor job progress and results
-
-## Requirements
-
-Before you begin, make sure you have:
-
-- A Windows or MacOS workstation
-- KeyShot Studio 2023 or 2024
-- [Deadline Cloud monitor](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/monitor-onboarding.html) installed
-- Access to an AWS Deadline Cloud farm with either
-    - a Windows service-managed fleet or
-    - a customer-managed fleet with KeyShot Studio, the KeyShot adapter, and licensing set up
-
-## Installation
-
-
-The KeyShot submitter extension allows you to submit jobs to Deadline Cloud directly from within KeyShot. To install the submitter,
-
-1. Download the [official Deadline Cloud submitter installer](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/submitter.html)
-2. Run the installer and follow the on-screen instructions
-3. Launch KeyShot after installation
-
-> Currently a submitter installer is only availble for Windows. See the [the developer README](../../README.md) for manual install instructions for Mac.
-
-To update the submitter to the latest version, download and run the latest submitter installer.
-
-
-## Using the Submitter
-
-### Preparing Your Scene
+## Preparing Your Scene
 
 Before submitting a job:
 
@@ -60,7 +8,7 @@ Before submitting a job:
 2. Set up your camera angles, materials, and lighting as desired
 3. Configure animation frames if rendering an animation
 
-### Submitting a Job
+## Submitting a Job
 
 1. In KeyShot, on the top toolbar click **Scripting Console**.
 2. In the Scripting Console, navigate to **Scripts** → **Submit to AWS Deadline Cloud**
@@ -68,7 +16,7 @@ Before submitting a job:
 
 ![Accessing the Submitter](./images/scripting-console.png)
 
-### Submission Options
+## Submission Options
 
 When you run the submitter, you'll first see a dialog asking how you want to handle file attachments:
 
@@ -86,7 +34,7 @@ Choose one of the following options:
   - Use this option if your workers already have access to all referenced files
   - Requires shared network storage or another method to access external files
 
-### Render Settings
+## Render Settings
 
 After selecting your submission option, the Deadline Cloud submitter interface will appear:
 

--- a/hatch.toml
+++ b/hatch.toml
@@ -52,3 +52,14 @@ version = "semantic-release -v --strict version --print {args}"
 
 [envs.installer.scripts]
 build-installer = "python {root}/scripts/build_installer_cli.py --installer-source-path {root}/installer/DeadlineCloudForKeyShotSubmitter.xml {args:}"
+
+[envs.docs]
+dependencies = [
+  "mkdocs>=1.5.0",
+  "mkdocs-material>=9.4.0",
+]
+
+[envs.docs.scripts]
+build = "mkdocs build"
+serve = "mkdocs serve"
+deploy = "mkdocs gh-deploy --force"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,37 @@
+site_name: AWS Deadline Cloud for KeyShot User Guide
+site_url: https://aws-deadline.github.io/deadline-cloud-for-keyshot/
+repo_url: https://github.com/aws-deadline/deadline-cloud-for-keyshot
+repo_name: aws-deadline/deadline-cloud-for-keyshot
+edit_uri: edit/mainline/docs/user_guide/
+
+theme:
+  name: material
+  palette:
+    primary: custom
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.expand
+    - content.code.copy
+extra_css:
+  - extra.css
+
+extra:
+  generator: false # Hide mkdocs-material call out
+
+copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+markdown_extensions:
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Installation: installation.md
+  - Using the Submitter: using-submitter.md
+
+plugins:
+  - search
+
+docs_dir: docs/user_guide
+site_dir: site


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We have a user guide, but it's a file in a GitHub repo that's not easily discoverable and which visually looks like a developer-oriented doc.

### What was the solution? (How)
Render the user guide as a static GitHub pages site using MkDocs.

There are many static site generators that read from markdown files, and MkDocs seemed like a common one for Python files. We can swap it out in the future with minimal effort.

There's a GitHub workflow which publishes the user guide as part of pushes to mainline.

See the user guide from my fork here: https://crowecawcaw.github.io/deadline-cloud-for-keyshot

### What is the impact of this change?
End users have a nicer place to find install and usage info.

### How was this change tested?
Published the user guide in my fork.

### Was this change documented?
Yes

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
