### PR TITLE
chore: various installer improvements

### DIFF
--- a/.github/workflows/build_installers.yml
+++ b/.github/workflows/build_installers.yml
@@ -3,27 +3,39 @@ name: "Build Installers"
 on:
   workflow_dispatch:
     inputs:
-      ref_type:
+      os:
         required: true
+        default: Windows
         type: choice
         options:
-        - heads
+        - MacOS
+        - Windows
+      ref_type:
+        required: true
+        default: heads
+        type: choice
+        options:
         - tags
-        default: "tags"
+        - heads
       ref:
         required: true
         type: string
-        default: "mainline"
+        default: mainline
+      environment:
+        required: true
+        type: choice
+        options:
+        - mainline
 
 jobs:
-  BuildInstallers:
+  BuildInstaller:
     if: (github.repository == 'aws-deadline/deadline-cloud-for-keyshot')
-    name: Build Installers
+    name: Build Installer
     uses: aws-deadline/.github/.github/workflows/reusable_build_installers.yml@mainline
     secrets: inherit
     with:
-      environment: "mainline"
+      environment: ${{inputs.environment}}
       ref_type: ${{inputs.ref_type}}
       ref: ${{inputs.ref}}
-      oses: "['Windows', 'MacOS']"
+      oses: "['${{inputs.os}}']"
       project_name: "deadline-cloud-for-keyshot"

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -17,7 +17,9 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: aws-deadline/.github/.github/workflows/reusable_publish.yml@mainline
+    uses: aws-deadline/.github/.github/workflows/reusable_publish_v2.yml@mainline
+    with:
+      installer_oses: "['Windows', 'MacOS']"
     secrets: inherit
   # PyPI does not support reusable workflows yet
   # # See https://github.com/pypi/warehouse/issues/11096
@@ -31,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: release
+          ref: ${{ needs.Publish.outputs.tag }}
           fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/scripts/_project.py
+++ b/scripts/_project.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Optional

--- a/scripts/build_installer.py
+++ b/scripts/build_installer.py
@@ -2,16 +2,14 @@
 """Script to create platform-specific Deadline Client installers using InstallBuilder."""
 
 import os
-import platform
 import sys
 import shutil
 import tempfile
-from datetime import datetime
 from typing import Optional
 from pathlib import Path
 
-from common import EvaluationBuildError, run
-from find_installbuilder import InstallBuilderSelection
+from common import EvaluationBuildError, run, get_version_string
+from find_installbuilder import InstallBuilderSelection, get_builder_exe_name
 
 # This is derived from <installerFilename> in installer/DeadlineCloudForKeyShotSubmitter.xml
 # See "Supported Platforms" table in https://releases.installbuilder.com/installbuilder/docs/installbuilder-userguide.html
@@ -48,17 +46,12 @@ def setup_install_builder(
 
     install_builder_path = selection.resolve_install_builder_installation(workdir)
 
-    if platform.system() == "Windows":
-        binary_name = "builder.exe"
-    else:
-        binary_name = "builder"
-
     if (
         not install_builder_path.is_dir()
-        or not (install_builder_path / "bin" / binary_name).is_file()
+        or not (install_builder_path / "bin" / get_builder_exe_name()).is_file()
     ):
         raise FileNotFoundError(
-            f"InstallBuilder path '{install_builder_path}' must be a directory containing 'bin/{binary_name}'."
+            f"InstallBuilder path '{install_builder_path}' must be a directory containing 'bin/{get_builder_exe_name()}'."
         )
 
     if license_file_path is not None:
@@ -73,6 +66,7 @@ def build_installer(
     install_builder_location: Path,
     installer_platform: str,
     dev: bool,
+    override_installer_version: Optional[str],
 ) -> Path:
     """
     Actually build the installer
@@ -98,9 +92,11 @@ def build_installer(
 
     install_builder_cli = install_builder_location / "bin" / "builder"
     out_dir = workdir / "out"
-    installer_version = os.getenv("INSTALLER_VERSION") if not dev else "00000000"
-    if installer_version is None:
-        raise ValueError("INSTALLER_VERSION environment variable must be set.")
+    root = Path(__file__).resolve().parent.parent
+    if override_installer_version is not None:
+        installer_version = override_installer_version
+    else:
+        installer_version = get_version_string(cwd=root)
     output = run(
         [
             install_builder_cli,
@@ -109,7 +105,7 @@ def build_installer(
             installbuilder_platform,
             "--setvars",
             f"project.outputDirectory={out_dir}",
-            f"project.version={installer_version[:8]}-{datetime.today().date()}",
+            f"project.version={installer_version}",
         ]
     )
     sys.stdout.write(
@@ -137,9 +133,9 @@ def main(
     install_builder_s3_bucket: Optional[str],
     install_builder_s3_key: Optional[str],
     output_dir: Optional[Path],
-    cleanup: bool,
     installer_platform: str,
     installer_source_path: Path,
+    override_installer_version: Optional[str],
 ) -> None:
     with tempfile.TemporaryDirectory() as wd:
         workdir = Path(wd)
@@ -159,6 +155,7 @@ def main(
             install_builder_location=installbuilder_path,
             dev=dev,
             installer_platform=installer_platform,
+            override_installer_version=override_installer_version,
         )
 
         installer_filename = INSTALLER_FILENAMES[installer_platform]
@@ -176,7 +173,7 @@ def main(
                 f"Found:\n\t{os.linesep.join([str(i) for i in installer_dir.iterdir()])}"
             )
 
-        output_path = installer_filename
+        output_path = Path(installer_filename)
         if output_dir:
             output_dir.mkdir(exist_ok=True)
             output_path = output_dir / output_path

--- a/scripts/build_installer_cli.py
+++ b/scripts/build_installer_cli.py
@@ -186,15 +186,11 @@ def _not_allowed_if_env_var_set(
     help="The directory to output the installer to",
 )
 @click.option(
-    "--no-cleanup",
-    is_flag=True,
-    help="If specified, do not clean up the temporary directory after building the installer",
-)
-@click.option(
     "--installer-source-path",
     type=Path,
     help="The path to the installer source xml file",
 )
+@click.option("--override-installer-version", type=str, help="Use this as the installer version.")
 def cli(
     install_builder_path: Optional[Path],
     install_builder_s3_bucket: Optional[str],
@@ -204,8 +200,8 @@ def cli(
     local_dev: bool,
     platform: str,
     output_dir: Optional[Path],
-    no_cleanup: bool,
     installer_source_path: Path,
+    override_installer_version: Optional[str],
 ) -> None:
     cli_body(
         install_builder_path,
@@ -216,8 +212,8 @@ def cli(
         local_dev,
         platform,
         output_dir,
-        no_cleanup,
         installer_source_path,
+        override_installer_version,
     )
 
 
@@ -230,8 +226,8 @@ def cli_body(
     local_dev: bool,
     platform: str,
     output_dir: Optional[Path],
-    no_cleanup: bool,
     installer_source_path: Path,
+    override_installer_version: Optional[str],
 ) -> None:
     """
     Separate from the command function so we can mock the body out
@@ -244,9 +240,9 @@ def cli_body(
         install_builder_s3_bucket,
         install_builder_s3_key,
         output_dir,
-        not no_cleanup,
         platform,
         installer_source_path,
+        override_installer_version,
     )
 
 

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -2,6 +2,9 @@
 import subprocess
 import sys
 
+from os import PathLike
+from typing import Union, Dict, Optional, List
+
 
 class BadExitCodeError(Exception):
     pass
@@ -15,23 +18,55 @@ class UnsupportedOSError(Exception):
     pass
 
 
-def run(cmd, cwd=None, env=None, echo=True):
+def run(
+    cmd: Union[PathLike, str, List[Union[str, PathLike]]],
+    cwd: Optional[Union[str, PathLike]] = None,
+    env: Optional[Dict[str, str]] = None,
+    echo: bool = True,
+) -> str:
     if echo:
         sys.stdout.write(f"Running cmd: {cmd}\n")
-    kwargs = {
-        "shell": True,
-        "stdout": subprocess.PIPE,
-        "stderr": subprocess.PIPE,
-    }
-    if isinstance(cmd, list):
-        kwargs["shell"] = False
-    if cwd is not None:
-        kwargs["cwd"] = cwd
-    if env is not None:
-        kwargs["env"] = env
-    p = subprocess.Popen(cmd, **kwargs)
+    shell = not isinstance(cmd, list)
+    p = subprocess.Popen(
+        cmd, shell=shell, cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
     stdout, stderr = p.communicate()
     output = stdout.decode("utf-8") + stderr.decode("utf-8")
+
     if p.returncode != 0:
-        raise BadExitCodeError(f"Bad rc ({p.returncode}) for cmd '{cmd}': {output}")
+        raise BadExitCodeError(
+            f"Process '{str(cmd)}' failed with exit code {p.returncode} and output: {output}"
+        )
+
     return output
+
+
+def get_latest_git_tag(cwd: Optional[Union[PathLike, str]] = None) -> str:
+    result = run(["git", "describe", "--tags", "--abbrev=0"], cwd=cwd, echo=False).strip()
+    return result
+
+
+def get_latest_commit_hash(cwd: Optional[Union[PathLike, str]] = None) -> str:
+    result = run(["git", "rev-parse", "HEAD"], cwd=cwd, echo=False).strip()
+    return result
+
+
+def get_latest_git_tag_hash(cwd: Optional[Union[PathLike, str]] = None) -> str:
+    tag = get_latest_git_tag(cwd)
+    result = run(["git", "rev-list", "-n", "1", tag], cwd=cwd, echo=False).strip()
+    return result
+
+
+def get_latest_commit_short_hash(cwd: Optional[Union[PathLike, str]] = None) -> str:
+    result = run(["git", "rev-parse", "--short", "HEAD"], cwd=cwd, echo=False).strip()
+    return result
+
+
+def get_version_string(cwd: Optional[Union[PathLike, str]] = None) -> str:
+    latest_tag = get_latest_git_tag(cwd)
+    latest_commit_hash = get_latest_commit_hash(cwd)
+    latest_tag_hash = get_latest_git_tag_hash(cwd)
+    if latest_commit_hash == latest_tag_hash:
+        return latest_tag
+    latest_commit_hash_short = get_latest_commit_short_hash()
+    return f"{latest_tag}.{latest_commit_hash_short}"

--- a/scripts/deps_bundle.py
+++ b/scripts/deps_bundle.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
 
-from _project import Dependency, get_dependencies, get_pip_platform, get_project_dict
+from _project import get_project_dict, get_dependencies, get_pip_platform, Dependency
 
 SUPPORTED_PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
 SUPPORTED_PLATFORMS = ["Windows", "Linux", "Darwin"]
@@ -102,13 +102,15 @@ def _zip_bundle(base_env: Path, zip_path: Path) -> None:
     shutil.make_archive(str(zip_path.with_suffix("")), "zip", str(base_env))
 
 
-def _copy_zip_to_destination(zip_path: Path) -> None:
+def _copy_zip_to_destination(zip_path: Path) -> Path:
     dependency_bundle_dir = Path.cwd() / "dependency_bundle"
     dependency_bundle_dir.mkdir(exist_ok=True)
     zip_destination = dependency_bundle_dir / zip_path.name
     if zip_destination.exists():
         zip_destination.unlink()
     shutil.copy(str(zip_path), str(zip_destination))
+
+    return zip_destination
 
 
 def build_deps_bundle() -> None:

--- a/scripts/find_installbuilder.py
+++ b/scripts/find_installbuilder.py
@@ -15,6 +15,7 @@ from common import UnsupportedOSError
 _INSTALL_BUILDER_ARCHIVE_FILENAME = {
     "Windows": "VMware-InstallBuilder-Professional-windows.tar.gz",
     "Linux": "VMware-InstallBuilder-Professional-linux.tar.gz",
+    "Darwin": "VMware-InstallBuilder-Professional-macos.tar.gz",
 }
 
 
@@ -150,6 +151,12 @@ class _InstallBuilderInstallation:
         )
 
 
+def get_builder_exe_name() -> str:
+    if platform.system() == "Windows":
+        return "builder.exe"
+    return "builder"
+
+
 def _get_default_installbuilder_location() -> Path:
     """
     Returns the default location where InstallBuilder Professional will be installed depending on the platform.
@@ -161,7 +168,7 @@ def _get_default_installbuilder_location() -> Path:
     for install_dir in config.parent_path.iterdir():
         if install_dir.is_dir():
             match = config.get_install_directory_regex().match(install_dir.name)
-            if match and (install_dir / "bin" / "builder").is_file():
+            if match and (install_dir / "bin" / get_builder_exe_name()).is_file():
                 if platform.system() == "Linux":
                     version_offset = 0
                 else:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Add various installer improvements, following Cinema 4D: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/197

### How was this change tested?

For Windows installer
`hatch build && hatch run lint && hatch run test && hatch run test-installer && hatch run installer:build-installer --install-builder-path "C:\\Program Files\\InstallBuilder Professional 24.3.0" --platform windows --local-dev`
Ran the installer on a Windows machine and confirmed it installed the `Submit to AWS Deadline Cloud.py` to the KeyShot scripts directory. Then used `uninstall.exe` and confirmed it removed `Submit to AWS Deadline Cloud.py`.

### Was this change documented?
No, N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
