### PR TITLE
test: allow tests to run on CodeBuild

### DIFF
--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -162,7 +162,7 @@ def test_default_location(installer_path: Path):
 
     assert (
         location is not None
-    ), f"Could not find default install location in help output:\n{help_result.stdout}"
+    ), f"Could not find default install location in help output:\n{help_output}"
     if platform.system() != "Windows":
         assert location.group(1) == default_install_location.as_posix()
     else:
@@ -170,7 +170,7 @@ def test_default_location(installer_path: Path):
 
 
 @pytest.mark.skipif(
-    os.getenv("CODEBUILD_SRC_DIR") is None,
+    os.getenv("CODEBUILD_SRC_DIR") is None or os.getenv("IS_DEV_BUILD", "false").lower() == "true",
     reason="Only installers built with a license will not be evaluation mode",
 )
 @pytest.mark.skipif(
@@ -252,7 +252,9 @@ class TestLinuxAndMacOS:
         # assists mypy type checking to ignore this on Windows
         assert sys.platform != "win32"
         # GIVEN
-        current_user = getpass.getuser()
+        import pwd
+
+        current_user = pwd.getpwuid(os.getuid())[0]  # type: ignore
 
         # WHEN
         bad_perms: defaultdict[Path, list[str]] = defaultdict(list)
@@ -290,6 +292,23 @@ class TestWindows:
         # GIVEN / WHEN / THEN
         self._verify_windows_least_privilege(system_installation)
 
+    def _running_in_container(self) -> bool:
+        """
+        Check to see if the cexecsvc service exists and is running
+        to determine if we're running on a container.
+        """
+        # assists mypy type checking to ignore this on non-Windows
+        assert sys.platform == "win32"
+        import win32service  # type: ignore
+        import win32serviceutil  # type: ignore
+
+        try:
+            service_status = win32serviceutil.QueryServiceStatus("cexecsvc")
+            return service_status[1] == win32service.SERVICE_RUNNING
+        except win32service.error:
+            # Service doesn't exist, not on a container
+            return False
+
     def _verify_windows_least_privilege(self, installation_path: Path):
         # assists mypy type checking to ignore this on non-Windows
         assert sys.platform == "win32"
@@ -300,7 +319,14 @@ class TestWindows:
 
         # GIVEN
         windows_user = getpass.getuser()
-        builtin_admin_group_sid, _, _ = win32security.LookupAccountName(None, "Administrators")
+        if self._running_in_container():
+            # The admin group is different when running
+            # in a container.
+            admin_group = "ContainerAdministrator"
+        else:
+            admin_group = "Administrators"
+
+        builtin_admin_group_sid, _, _ = win32security.LookupAccountName(None, admin_group)
         user_sid, _, _ = win32security.LookupAccountName(None, windows_user)
 
         # WHEN
@@ -316,7 +342,7 @@ class TestWindows:
             if _is_admin():
                 if builtin_admin_group_sid != owner_sid:
                     bad_perms[path].append(
-                        f"Expected to be owned by 'Administrators' but got '{win32security.LookupAccountSid(None, owner_sid)}'"
+                        f"Expected to be owned by '{admin_group}' but got '{win32security.LookupAccountSid(None, owner_sid)}'"
                     )
             elif user_sid != owner_sid:
                 bad_perms[path].append(
@@ -415,7 +441,7 @@ class TestSystemInstall:
 
 
 @pytest.mark.skipif(
-    os.getenv("CODEBUILD_SRC_DIR") is None,
+    os.getenv("CODEBUILD_SRC_DIR") is None or os.getenv("IS_DEV_BUILD", "false").lower() == "true",
     reason="Only installers built internally will be signed",
 )
 class TestVerifySigning:
@@ -440,7 +466,12 @@ class TestVerifySigning:
             Number of errors: 1
         """
         # GIVEN
-        signtool = next(glob.iglob("C:/Program Files*/Windows Kits/*/bin/*/x64/signtool.exe"), None)
+        # Check PATH, then SDK installation location
+        signtool = shutil.which("signtool")
+        if not signtool:
+            signtool = next(
+                glob.iglob("C:/Program Files*/Windows Kits/*/bin/*/x64/signtool.exe"), None
+            )
         assert signtool, "signtool not found in expected location"
 
         # WHEN


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Tests were failing on CodeBuild for automated installer builds. Fixed the tests.

### How was this change tested?
`hatch run test-installer` passes

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
