### PR TITLE
test: fix fixture name in installer test

### DIFF
--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -437,9 +437,9 @@ class TestUserInstall:
 
 @pytest.mark.skipif(not _is_admin(), reason="Tests requires admin privileges")
 class TestSystemInstall:
-    def test_install(self, system_installation: Path, system_installation_scripts_dir: Path):
+    def test_install(self, system_installation: Path, system_installation_scripts_path: Path):
         # GIVEN / WHEN / THEN
-        _validate_files(system_installation, system_installation_scripts_dir)
+        _validate_files(system_installation, system_installation_scripts_path)
 
     def test_uninstall(self, per_test_system_installation: Path, uninstaller_path: Path):
         # GIVEN / WHEN


### PR DESCRIPTION
Tests were failing on `fixture 'system_installation_scripts_dir' not found`

Determined that https://github.com/aws-deadline/deadline-cloud-for-keyshot/pull/199 used the incorrect fixture name, it should have been `system_installation_scripts_path`. Updated the fixture name.

Tested by opening a `cmd` Window in Adminstrator mode, then running `hatch build && hatch run test-installer` with result `7 passed, 5 skipped in 101.33s (0:01:41)`