### PR TITLE
fix: create the installation directory for the uninstaller and installer_version.txt files

### DIFF
--- a/installer/DeadlineCloudForKeyShotSubmitter.xml
+++ b/installer/DeadlineCloudForKeyShotSubmitter.xml
@@ -214,6 +214,9 @@
     </preInstallationActionList>
     <postInstallationActionList>
         <setInstallerVariable name="installscope" value="${installscope}" persist="1"/>
+        <createDirectory>
+            <path>${installdir}</path>
+        </createDirectory>
         <writeFile>
             <progressText>Writing version file</progressText>
             <path>${installdir}/installer_version.txt</path>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Mac installer build was failing due to error
`Problem running post-install step. Installation may not complete correctly
 Error writing file /private/tmp/pytest-of-root/pytest-15/popen-gw0/test_uninstall0/dne/installer_version.txt`

### What was the solution? (How)
It appears that this is failing due to the folder not being created. Pre-created the folder.

### How was this tested?
Ran the installer build, it passed!

Also manually installed and uninstalled the submitter and confirmed that the install directory was deleted after the uninstall.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
