### PR TITLE
feat: add default locations for script installation on Mac and add UI hint

### DIFF
--- a/install_builder/deadline-cloud-for-keyshot.xml
+++ b/install_builder/deadline-cloud-for-keyshot.xml
@@ -71,7 +71,40 @@
                         <setInstallerVariable name="keyshot_scripts_directory" value="${env(KEYSHOT12)}\Scripts"/>
                     </actionList>
                     <elseActionList>
-                        <setInstallerVariable name="keyshot_scripts_directory" value=""/>
+                        <if>
+                            <conditionRuleList>
+                                <platformTest type="osx" />
+                            </conditionRuleList>
+                            <actionList>
+                                <if>
+                                    <conditionRuleList>
+                                        <!-- KeyShot 2024.2+ -->
+                                        <fileExists path="/Library/Application Support/KeyShot Studio/Scripts"/>
+                                    </conditionRuleList>
+                                    <actionList>
+                                        <setInstallerVariable name="keyshot_scripts_directory" value="/Library/Application Support/KeyShot Studio/Scripts"/>
+                                    </actionList>
+                                    <elseActionList>
+                                    <if>
+                                        <conditionRuleList>
+                                            <!-- KeyShot 2024.1 -->
+                                            <fileExists path="/Library/Application Support/KeyShot/Scripts"/>
+                                        </conditionRuleList>
+                                        <actionList>
+                                            <setInstallerVariable name="keyshot_scripts_directory" value="/Library/Application Support/KeyShot/Scripts"/>
+                                        </actionList>
+                                        <elseActionList>
+                                            <!-- KeyShot 2023 -->
+                                            <setInstallerVariable name="keyshot_scripts_directory" value="/Library/Application Support/KeyShot 12/Scripts"/>
+                                        </elseActionList>
+                                    </if>
+                                    </elseActionList>
+                                </if>
+                            </actionList>
+                            <elseActionList>
+                                <setInstallerVariable name="keyshot_scripts_directory" value=""/>
+                            </elseActionList>
+                        </if>
                     </elseActionList>
                 </if>
             </elseActionList>
@@ -94,7 +127,12 @@
         <directoryParameter>
             <name>keyshot_scripts_directory</name>
             <description>KeyShot Scripts Directory</description>
-            <explanation>Path to scripts directory in the KeyShot resources directory. For easiest installation, KeyShot should be installed before installing Deadline Cloud for KeyShot.</explanation>
+            <explanation>
+Path to scripts directory in the KeyShot resources directory. For easiest installation, KeyShot should be installed before installing Deadline Cloud for KeyShot.
+Examples:
+Windows: C:\Users\Username\Documents\KeyShot Studio\Scripts
+Mac: /Library/Application Support/KeyShot Studio/Scripts
+            </explanation>
             <allowEmptyValue>0</allowEmptyValue>
             <ask>yes</ask>
             <cliOptionName>keyshot-scripts-directory</cliOptionName>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Since Mac does not support environment variables, the KeyShot scripts directory in the installer was always blank.

### What was the solution? (How)
Added auto-detection for common KeyShot installation locations as well as some UI hints about where to look.

### What is the impact of this change?
Easier installation for all users.

### How was this change tested?
Windows:
`hatch build && hatch run lint && hatch run test && hatch run installer:build-installer --install-builder-path "C:\\Program Files\\InstallBuilder Professional 24.3.0" --platform windows --local-dev && hatch run test-installer`

Manually opened the installer and reviewed the text. Confirmed that the scripts directory was pre-filled.

![image](https://github.com/user-attachments/assets/cbf1fc71-7f21-4c4f-988a-fe7dfcbee4b8)

Mac:
`hatch build && hatch run lint && hatch run test && hatch run installer:build-installer --install-builder-path "/Applications/Library Support/InstallBuilder Professional 24.3.0" --platform osx --local-dev && hatch run test-installer`

### Was this change documented?
No, N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
