### PR TITLE
fix: add environment enter and exit timeouts

### DIFF
--- a/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
+++ b/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
@@ -19,6 +19,14 @@ SUBMISSION_MODE_KEY = "submission_mode"
 # Unique ID required to allow KeyShot to save selections for a dialog
 DEADLINE_CLOUD_DIALOG_ID = "e309ce79-3ee8-446a-8308-10d16dfcbb42"
 
+_SERVER_START_TIMEOUT_SECONDS = 30
+_SERVER_END_TIMEOUT_SECONDS = 30
+_KEYSHOT_START_TIMEOUT_SECONDS = 300
+_KEYSHOT_END_TIMEOUT_SECONDS = 30
+
+KEYSHOT_ENVIRON_ENTER_TIMEOUT = _SERVER_START_TIMEOUT_SECONDS + _KEYSHOT_START_TIMEOUT_SECONDS + 60
+KEYSHOT_ENVIRON_EXIT_TIMEOUT = _SERVER_END_TIMEOUT_SECONDS + _KEYSHOT_END_TIMEOUT_SECONDS + 60
+
 
 @dataclass
 class Settings:
@@ -205,6 +213,7 @@ def construct_job_template(filename: str) -> dict:
                                         "file://{{Env.File.initData}}",
                                     ],
                                     "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
+                                    "timeout": KEYSHOT_ENVIRON_ENTER_TIMEOUT,
                                 },
                                 "onExit": {
                                     "command": "keyshot-openjd",
@@ -215,6 +224,7 @@ def construct_job_template(filename: str) -> dict:
                                         "{{ Session.WorkingDirectory }}/connection.json",
                                     ],
                                     "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
+                                    "timeout": KEYSHOT_ENVIRON_EXIT_TIMEOUT,
                                 },
                             },
                         },

--- a/test/integ/cube/expected_bundle/template.json
+++ b/test/integ/cube/expected_bundle/template.json
@@ -110,7 +110,8 @@
                                 ],
                                 "cancelation": {
                                     "mode": "NOTIFY_THEN_TERMINATE"
-                                }
+                                },
+                                "timeout": 390
                             },
                             "onExit": {
                                 "command": "keyshot-openjd",
@@ -122,7 +123,8 @@
                                 ],
                                 "cancelation": {
                                     "mode": "NOTIFY_THEN_TERMINATE"
-                                }
+                                },
+                                "timeout": 120
                             }
                         }
                     }

--- a/test/unit/keyshot_submitter/test_keyshot_submitter.py
+++ b/test/unit/keyshot_submitter/test_keyshot_submitter.py
@@ -373,3 +373,12 @@ def test_get_ksp_bundle_files():
         assert len(input_filenames) == 1
         assert input_filenames[0] == os.path.join(temp_dir, "unpack", TEST_ASSET_FILE)
         mock_save_ksp_bundle.assert_called_once_with(os.path.join(temp_dir, "ksp"), mock.ANY)
+
+def test_construct_job_template_timeout_values():
+
+    template = submitter.construct_job_template("test_scene.bip")
+
+    actions = template["steps"][0]["stepEnvironments"][0]["script"]["actions"]
+    
+    assert actions["onEnter"]["timeout"] == submitter.KEYSHOT_ENVIRON_ENTER_TIMEOUT
+    assert actions["onExit"]["timeout"] == submitter.KEYSHOT_ENVIRON_EXIT_TIMEOUT

--- a/test/unit/keyshot_submitter/test_keyshot_submitter.py
+++ b/test/unit/keyshot_submitter/test_keyshot_submitter.py
@@ -374,11 +374,12 @@ def test_get_ksp_bundle_files():
         assert input_filenames[0] == os.path.join(temp_dir, "unpack", TEST_ASSET_FILE)
         mock_save_ksp_bundle.assert_called_once_with(os.path.join(temp_dir, "ksp"), mock.ANY)
 
+
 def test_construct_job_template_timeout_values():
 
     template = submitter.construct_job_template("test_scene.bip")
 
     actions = template["steps"][0]["stepEnvironments"][0]["script"]["actions"]
-    
+
     assert actions["onEnter"]["timeout"] == submitter.KEYSHOT_ENVIRON_ENTER_TIMEOUT
     assert actions["onExit"]["timeout"] == submitter.KEYSHOT_ENVIRON_EXIT_TIMEOUT


### PR DESCRIPTION
Fixes: *https://github.com/aws-deadline/deadline-cloud-for-keyshot/issues/179*

### What was the problem/requirement? (What/Why)
The KeyShot adaptor's environment enter and exits do not have a timeout specified in their job template. If the environment enter or exit get stuck (and the first layer of timeouts doesn't work), then the worker agent does not enforce the timeout.

### What was the solution? (How)
Added a timeout to the environment enter and exit actions, using the OpenJD spec timeout field. Added a unit test to test this change.

### What is the impact of this change?
This change will prevent worker agents from getting stuck indefinitely if there are issues during KeyShot startup or shutdown.

### How was this change tested?
This change was tested by creating an additional unit test (`test_construct_job_template_timeout_values`) and via `hatch run integ:test`.

### Was this change documented?
No, as just the timeout values were added, along with a unit test and a change in the expected `template.json` file that adds in the timeout parameter.

### Is this a breaking change?
No, it is not a breaking change.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
