### PR TITLE
fix: print adaptor version during adaptor initialization in session logs

### DIFF
--- a/src/deadline/keyshot_adaptor/KeyShotAdaptor/adaptor.py
+++ b/src/deadline/keyshot_adaptor/KeyShotAdaptor/adaptor.py
@@ -75,6 +75,10 @@ class KeyShotAdaptor(Adaptor[AdaptorConfiguration]):
     _expected_outputs: int = 1  # Total number of renders to perform.
     _produced_outputs: int = 0  # Counter for tracking number of complete renders.
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        print(f"Deadline Cloud for KeyShot adaptor version: {adaptor_version}")
+
     @property
     def integration_data_interface_version(self) -> SemanticVersion:
         return SemanticVersion(major=0, minor=1)

--- a/test/unit/keyshot_adaptor/KeyShotAdaptor/test_adaptor.py
+++ b/test/unit/keyshot_adaptor/KeyShotAdaptor/test_adaptor.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from deadline.keyshot_adaptor.KeyShotAdaptor.adaptor import KeyShotAdaptor
+from deadline.keyshot_adaptor._version import version as adaptor_version
 
 # if this changes, the `integration_data_interface_version` should also be bumped
 CURRENT_INIT_DATA_SCHEMA = {
@@ -84,3 +85,13 @@ def test_if_init_data_and_run_data_schema_are_changed_schema_version_is_bumped(i
     # also be bumped
     assert semantic_version.major == 0
     assert semantic_version.minor == 1
+
+
+def test_adaptor_prints_version_on_init(init_data, capfd):
+    """
+    Test that the adaptor prints its version during initialization
+    """
+    KeyShotAdaptor(init_data)
+    captured = capfd.readouterr()
+    expected_output = f"Deadline Cloud for KeyShot adaptor version: {adaptor_version}"
+    assert expected_output in captured.out


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-keyshot/issues/204

### What was the problem/requirement? (What/Why)
Output the adaptor version in the session logs during environment enter.

### What was the solution? (How)
Added a print statement when initializing the adaptor.

### What is the impact of this change?
When debugging issues, it is helpful to know what version of the adaptor is being used.

### How was this change tested?
I wrote a unit test in test_adaptor.py to test the change, ran hatch integration tests, and also setup my dev environment to build Conda packages and uploaded them to a custom Conda channel to test.

### Was this change documented?
N/A

### Is this a breaking change?
N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
