### PR TITLE
fix: turn off viewport rendering to reduce CPU usage

### DIFF
--- a/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_client.py
+++ b/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_client.py
@@ -46,6 +46,7 @@ class KeyShotClient(ClientInterface):
         super().__init__(server_path=server_path)
         major_version, minor_version = lux.getKeyShotDisplayVersion()
         print(f"KeyShotClient: KeyShot Version {major_version}.{minor_version}")
+        lux.pause()
         self.actions.update(KeyShotHandler().action_dict)
 
     def close(self, args: Optional[dict] = None) -> None:

--- a/test/unit/keyshot_adaptor/KeyShotClient/test_keyshot_client.py
+++ b/test/unit/keyshot_adaptor/KeyShotClient/test_keyshot_client.py
@@ -16,3 +16,9 @@ def mock_get_keyshot_display_version():
 
 def test_keyshot_client_creation():
     KeyShotClient("127.0.01")
+
+
+def test_keyshot_client_pauses_viewport_rendering():
+    with mock.patch.object(lux, "pause") as pause_mock:
+        KeyShotClient("127.0.01")
+        pause_mock.assert_called_once()


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-keyshot/issues/117

### What was the problem/requirement? (What/Why)
KeyShot initiates viewport rendering automatically upon scene loading, even in headless mode. By default, this process consumes maximum available CPU resources.

### What was the solution? (How)
Adding lux.pause() in the init() method of keyshot_client.py to turn off viewport rendering.

### What is the impact of this change?
Implementing lux.pause() disables viewport rendering, significantly reducing CPU utilization when the system is idle, allowing resources to be allocated more efficiently for actual rendering tasks when they begin.

### How was this change tested?
I wrote a unit test for the change that passed, ran hatch integration tests, tested the changes in my own Conda environment, and then also took a look at both the Task Manager and Performance Monitor and visually compared how much % Processor Time python, keyshot_headless, and keyshot_openjd took up when running the integration tests with viewport rendering off, and then with it on. The differences demonstrate that CPU usage is indeed reduced.

The graphs from the Performance Monitor are attached here:
With viewport rendering turned off:
![with pause](https://github.com/user-attachments/assets/2fecfff1-3ad4-499d-8d74-265b2227c217)

With viewport rendering turned on:
![without pause](https://github.com/user-attachments/assets/bd73a5c8-fc0d-4d96-b7be-0a52de4f712d)

### Was this change documented?
N/A

### Is this a breaking change?
N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
