### PR TITLE
fix!: Configure GPU rendering with host requirements via GUI

### DIFF
--- a/src/deadline/keyshot_adaptor/KeyShotAdaptor/adaptor.py
+++ b/src/deadline/keyshot_adaptor/KeyShotAdaptor/adaptor.py
@@ -33,6 +33,7 @@ _FIRST_KEYSHOT_ACTIONS = [
     "output_file_path",
     "output_format",
     "render_options",
+    "override_render_device",
     "render_device",
 ]
 

--- a/src/deadline/keyshot_adaptor/KeyShotAdaptor/adaptor.py
+++ b/src/deadline/keyshot_adaptor/KeyShotAdaptor/adaptor.py
@@ -28,7 +28,13 @@ class KeyShotNotRunningError(Exception):
     """Error that is raised when attempting to use KeyShot while it is not running"""
 
 
-_FIRST_KEYSHOT_ACTIONS = ["scene_file", "output_file_path", "output_format", "render_options"]
+_FIRST_KEYSHOT_ACTIONS = [
+    "scene_file",
+    "output_file_path",
+    "output_format",
+    "render_options",
+    "render_device",
+]
 
 _KEYSHOT_RUN_KEYS = {"frame"}
 
@@ -81,7 +87,7 @@ class KeyShotAdaptor(Adaptor[AdaptorConfiguration]):
 
     @property
     def integration_data_interface_version(self) -> SemanticVersion:
-        return SemanticVersion(major=0, minor=3)
+        return SemanticVersion(major=0, minor=2)
 
     @staticmethod
     def _get_timer(timeout: int | float) -> Callable[[], bool]:

--- a/src/deadline/keyshot_adaptor/KeyShotAdaptor/adaptor.py
+++ b/src/deadline/keyshot_adaptor/KeyShotAdaptor/adaptor.py
@@ -81,7 +81,7 @@ class KeyShotAdaptor(Adaptor[AdaptorConfiguration]):
 
     @property
     def integration_data_interface_version(self) -> SemanticVersion:
-        return SemanticVersion(major=0, minor=2)
+        return SemanticVersion(major=0, minor=3)
 
     @staticmethod
     def _get_timer(timeout: int | float) -> Callable[[], bool]:

--- a/src/deadline/keyshot_adaptor/KeyShotAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/keyshot_adaptor/KeyShotAdaptor/schemas/init_data.schema.json
@@ -23,6 +23,9 @@
         "render_device": {
             "enum": ["CPU", "GPU"]
         },
+        "override_render_device": {
+            "type": "boolean"
+        },
         "render_options": {
             "type": "object"
         }

--- a/src/deadline/keyshot_adaptor/KeyShotAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/keyshot_adaptor/KeyShotAdaptor/schemas/init_data.schema.json
@@ -20,7 +20,7 @@
                 "RENDER_OUTPUT_PSD32"
             ]
         },
-        "render_engine": {
+        "render_device": {
             "enum": ["CPU", "GPU"]
         },
         "render_options": {

--- a/src/deadline/keyshot_adaptor/KeyShotAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/keyshot_adaptor/KeyShotAdaptor/schemas/init_data.schema.json
@@ -20,6 +20,9 @@
                 "RENDER_OUTPUT_PSD32"
             ]
         },
+        "render_engine": {
+            "enum": ["CPU", "GPU"]
+        },
         "render_options": {
             "type": "object"
         }

--- a/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_handler.py
+++ b/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_handler.py
@@ -66,7 +66,7 @@ class KeyShotHandler:
         current_engine = lux.getRenderEngine()
         engine_name = engine_names[current_engine]
 
-        override_chosen = self.render_kwargs["override_render_device"]
+        override_chosen = self.render_kwargs.get("override_render_device", False)
         if override_chosen:
             print("Option to override the Keyshot render device was selected.")
             if self.render_kwargs["current_device"] == self.render_kwargs["render_device"]:
@@ -180,32 +180,31 @@ class KeyShotHandler:
         Raises:
             RuntimeError: If GPU rendering is requested but no compatible GPU is available
         """
-        override_render_device = self.render_kwargs["override_render_device"]
+        override_render_device = self.render_kwargs.get("override_render_device", False)
         self.original_render_device_param = data["render_device"]
 
         current_engine = lux.getRenderEngine()
         is_gpu = current_engine in [lux.RENDER_ENGINE_PRODUCT_GPU, lux.RENDER_ENGINE_INTERIOR_GPU]
         self.render_kwargs["current_device"] = "GPU" if is_gpu else "CPU"
+        self.render_kwargs["render_device"] = (
+            data["render_device"]
+            if override_render_device
+            else self.render_kwargs["current_device"]
+        )
 
-        if not override_render_device:
-            self.render_kwargs["render_device"] = "GPU" if is_gpu else "CPU"
-        else:
-            self.render_kwargs["render_device"] = data["render_device"]
-
-        if self.render_kwargs["render_device"] == "GPU":
-            if not is_gpu:
-                engine_map = {
-                    lux.RENDER_ENGINE_PRODUCT: lux.RENDER_ENGINE_PRODUCT_GPU,
-                    lux.RENDER_ENGINE_INTERIOR: lux.RENDER_ENGINE_INTERIOR_GPU,
-                }
-                if current_engine in engine_map:
-                    try:
-                        lux.setRenderEngine(engine_map[current_engine])
-                    except Exception:
-                        raise RuntimeError(
-                            "GPU rendering was requested but no compatible GPU is available on this worker. Please manually set min GPUs to 1 under 'Host requirements' in the KeyShot integrated submitter."
-                        )
-        elif override_render_device and self.render_kwargs["render_device"] == "CPU" and is_gpu:
+        if self.render_kwargs["render_device"] == "GPU" and not is_gpu:
+            engine_map = {
+                lux.RENDER_ENGINE_PRODUCT: lux.RENDER_ENGINE_PRODUCT_GPU,
+                lux.RENDER_ENGINE_INTERIOR: lux.RENDER_ENGINE_INTERIOR_GPU,
+            }
+            if current_engine in engine_map:
+                try:
+                    lux.setRenderEngine(engine_map[current_engine])
+                except Exception:
+                    raise RuntimeError(
+                        "GPU rendering was requested but no compatible GPU is available on this worker. Please manually set min GPUs to 1 under 'Host requirements' in the KeyShot integrated submitter."
+                    )
+        elif self.render_kwargs["render_device"] == "CPU" and is_gpu:
             engine_map = {
                 lux.RENDER_ENGINE_PRODUCT_GPU: lux.RENDER_ENGINE_PRODUCT,
                 lux.RENDER_ENGINE_INTERIOR_GPU: lux.RENDER_ENGINE_INTERIOR,

--- a/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_handler.py
+++ b/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_handler.py
@@ -66,26 +66,30 @@ class KeyShotHandler:
         current_engine = lux.getRenderEngine()
         engine_name = engine_names[current_engine]
 
+        current_device = self.render_kwargs.get("current_device", get_current_render_device())
+        render_device = self.render_kwargs.get("render_device", current_device)
         override_chosen = self.render_kwargs.get("override_render_device", False)
+
         if override_chosen:
             print("Option to override the Keyshot render device was selected.")
-            if self.render_kwargs["current_device"] == self.render_kwargs["render_device"]:
+            if current_device == render_device:
                 print(
-                    f"KeyShot render device {self.render_kwargs['render_device']} is already selected. Chosen override option matches Keyshot setting.\n"
+                    f"KeyShot render device {render_device} is already selected. Chosen override option matches Keyshot setting.\n"
                 )
             else:
-                print(
-                    f"Overriding {self.render_kwargs['current_device']} with {self.render_kwargs['render_device']}...\n"
-                )
+                print(f"Overriding {current_device} with {render_device}...\n")
         else:
             print("Option to override the Keyshot render device was NOT selected.")
-            if self.render_kwargs["current_device"] != self.original_render_device_param:
+            if (
+                current_device != self.original_render_device_param
+                and self.original_render_device_param is not None
+            ):
                 print(
                     f"WARNING: RenderDevice value from the submitter ({self.original_render_device_param}) will be ignored since override is not selected.\n"
                 )
 
         print(f"Selected render engine: {engine_name}")
-        print(f"Selected render device: {self.render_kwargs['render_device']}")
+        print(f"Selected render device: {render_device}")
 
         print("Starting Render...")
         frame = self.render_kwargs["frame"]
@@ -182,17 +186,19 @@ class KeyShotHandler:
         """
         override_render_device = self.render_kwargs.get("override_render_device", False)
         self.original_render_device_param = data["render_device"]
-
         current_engine = lux.getRenderEngine()
-        is_gpu = current_engine in [lux.RENDER_ENGINE_PRODUCT_GPU, lux.RENDER_ENGINE_INTERIOR_GPU]
-        self.render_kwargs["current_device"] = "GPU" if is_gpu else "CPU"
+
+        self.render_kwargs["current_device"] = get_current_render_device()
         self.render_kwargs["render_device"] = (
             data["render_device"]
             if override_render_device
             else self.render_kwargs["current_device"]
         )
 
-        if self.render_kwargs["render_device"] == "GPU" and not is_gpu:
+        if (
+            self.render_kwargs["render_device"] == "GPU"
+            and self.render_kwargs["current_device"] == "CPU"
+        ):
             engine_map = {
                 lux.RENDER_ENGINE_PRODUCT: lux.RENDER_ENGINE_PRODUCT_GPU,
                 lux.RENDER_ENGINE_INTERIOR: lux.RENDER_ENGINE_INTERIOR_GPU,
@@ -204,10 +210,19 @@ class KeyShotHandler:
                     raise RuntimeError(
                         "GPU rendering was requested but no compatible GPU is available on this worker. Please manually set min GPUs to 1 under 'Host requirements' in the KeyShot integrated submitter."
                     )
-        elif self.render_kwargs["render_device"] == "CPU" and is_gpu:
+        elif (
+            self.render_kwargs["render_device"] == "CPU"
+            and self.render_kwargs["current_device"] == "GPU"
+        ):
             engine_map = {
                 lux.RENDER_ENGINE_PRODUCT_GPU: lux.RENDER_ENGINE_PRODUCT,
                 lux.RENDER_ENGINE_INTERIOR_GPU: lux.RENDER_ENGINE_INTERIOR,
             }
             if current_engine in engine_map:
                 lux.setRenderEngine(engine_map[current_engine])
+
+
+def get_current_render_device() -> str:
+    current_engine = lux.getRenderEngine()
+    is_gpu = current_engine in [lux.RENDER_ENGINE_PRODUCT_GPU, lux.RENDER_ENGINE_INTERIOR_GPU]
+    return "GPU" if is_gpu else "CPU"

--- a/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_handler.py
+++ b/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_handler.py
@@ -32,6 +32,7 @@ class KeyShotHandler:
         self.render_kwargs = {}
         self.output_path = ""
         self.output_format_code = lux.RENDER_OUTPUT_PNG  # Default to PNG
+        self.original_render_device_param = None
 
     def set_output_file_path(self, data: dict) -> None:
         """
@@ -64,18 +65,27 @@ class KeyShotHandler:
 
         current_engine = lux.getRenderEngine()
         engine_name = engine_names[current_engine]
-        print(f"Selected render engine: {engine_name}")
-        selected_render_device = self.render_kwargs["render_device"]
-        print(f"Selected render device: {selected_render_device}")
-        override_chosen = self.render_kwargs["override_render_device"]
-        print(f"Override Keyshot render device chosen?: {override_chosen}\n")
 
-        if override_chosen and (
-            self.render_kwargs["current_device"] != self.render_kwargs["render_device"]
-        ):
-            print(
-                f"Overriding {self.render_kwargs['current_device']} with {self.render_kwargs['render_device']}...\n"
-            )
+        override_chosen = self.render_kwargs["override_render_device"]
+        if override_chosen:
+            print("Option to override the Keyshot render device was selected.")
+            if self.render_kwargs["current_device"] == self.render_kwargs["render_device"]:
+                print(
+                    f"KeyShot render device {self.render_kwargs['render_device']} is already selected. Chosen override option matches Keyshot setting.\n"
+                )
+            else:
+                print(
+                    f"Overriding {self.render_kwargs['current_device']} with {self.render_kwargs['render_device']}...\n"
+                )
+        else:
+            print("Option to override the Keyshot render device was NOT selected.")
+            if self.render_kwargs["current_device"] != self.original_render_device_param:
+                print(
+                    f"WARNING: RenderDevice value from the submitter ({self.original_render_device_param}) will be ignored since override is not selected.\n"
+                )
+
+        print(f"Selected render engine: {engine_name}")
+        print(f"Selected render device: {self.render_kwargs['render_device']}")
 
         print("Starting Render...")
         frame = self.render_kwargs["frame"]
@@ -158,7 +168,7 @@ class KeyShotHandler:
         Args:
             data (dict): The data given from the Adaptor. Keys expected: ['override_render_device']
         """
-        self.render_kwargs["override_render_device"] = data["override_render_device"]
+        self.render_kwargs["override_render_device"] = data.get("override_render_device", False)
 
     def set_render_device(self, data: dict) -> None:
         """
@@ -171,6 +181,7 @@ class KeyShotHandler:
             RuntimeError: If GPU rendering is requested but no compatible GPU is available
         """
         override_render_device = self.render_kwargs["override_render_device"]
+        self.original_render_device_param = data["render_device"]
 
         current_engine = lux.getRenderEngine()
         is_gpu = current_engine in [lux.RENDER_ENGINE_PRODUCT_GPU, lux.RENDER_ENGINE_INTERIOR_GPU]
@@ -182,18 +193,18 @@ class KeyShotHandler:
             self.render_kwargs["render_device"] = data["render_device"]
 
         if self.render_kwargs["render_device"] == "GPU":
-            try:
-                if not is_gpu:
-                    engine_map = {
-                        lux.RENDER_ENGINE_PRODUCT: lux.RENDER_ENGINE_PRODUCT_GPU,
-                        lux.RENDER_ENGINE_INTERIOR: lux.RENDER_ENGINE_INTERIOR_GPU,
-                    }
-                    if current_engine in engine_map:
+            if not is_gpu:
+                engine_map = {
+                    lux.RENDER_ENGINE_PRODUCT: lux.RENDER_ENGINE_PRODUCT_GPU,
+                    lux.RENDER_ENGINE_INTERIOR: lux.RENDER_ENGINE_INTERIOR_GPU,
+                }
+                if current_engine in engine_map:
+                    try:
                         lux.setRenderEngine(engine_map[current_engine])
-            except Exception:
-                raise RuntimeError(
-                    "GPU rendering was requested but no compatible GPU is available on this worker. Please manually set min GPUs to 1 under 'Host requirements' in the KeyShot integrated submitter."
-                )
+                    except Exception:
+                        raise RuntimeError(
+                            "GPU rendering was requested but no compatible GPU is available on this worker. Please manually set min GPUs to 1 under 'Host requirements' in the KeyShot integrated submitter."
+                        )
         elif override_render_device and self.render_kwargs["render_device"] == "CPU" and is_gpu:
             engine_map = {
                 lux.RENDER_ENGINE_PRODUCT_GPU: lux.RENDER_ENGINE_PRODUCT,

--- a/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_handler.py
+++ b/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_handler.py
@@ -25,6 +25,7 @@ class KeyShotHandler:
             "output_format": self.set_output_format,
             "frame": self.set_frame,
             "render_options": self.set_render_options,
+            "override_render_device": self.set_override_render_device,
             "render_device": self.set_render_device,
             "start_render": self.start_render,
         }
@@ -54,8 +55,27 @@ class KeyShotHandler:
             RuntimeError: .
         """
 
+        engine_names = {
+            0: "RENDER_ENGINE_PRODUCT",
+            1: "RENDER_ENGINE_INTERIOR",
+            3: "RENDER_ENGINE_PRODUCT_GPU",
+            4: "RENDER_ENGINE_INTERIOR_GPU",
+        }
+
+        current_engine = lux.getRenderEngine()
+        engine_name = engine_names[current_engine]
+        print(f"Selected render engine: {engine_name}")
         selected_render_device = self.render_kwargs["render_device"]
         print(f"Selected render device: {selected_render_device}")
+        override_chosen = self.render_kwargs["override_render_device"]
+        print(f"Override Keyshot render device chosen?: {override_chosen}\n")
+
+        if override_chosen and (
+            self.render_kwargs["current_device"] != self.render_kwargs["render_device"]
+        ):
+            print(
+                f"Overriding {self.render_kwargs['current_device']} with {self.render_kwargs['render_device']}...\n"
+            )
 
         print("Starting Render...")
         frame = self.render_kwargs["frame"]
@@ -131,6 +151,15 @@ class KeyShotHandler:
         if "render_options" in data:
             self.render_kwargs["render_options"] = data["render_options"]
 
+    def set_override_render_device(self, data: dict) -> None:
+        """
+        Sets the override render device flag
+
+        Args:
+            data (dict): The data given from the Adaptor. Keys expected: ['override_render_device']
+        """
+        self.render_kwargs["override_render_device"] = data["override_render_device"]
+
     def set_render_device(self, data: dict) -> None:
         """
         Sets the render engine (CPU or GPU) based on the parameter value.
@@ -141,25 +170,34 @@ class KeyShotHandler:
         Raises:
             RuntimeError: If GPU rendering is requested but no compatible GPU is available
         """
-        self.render_kwargs["render_device"] = data["render_device"]
+        override_render_device = self.render_kwargs["override_render_device"]
 
         current_engine = lux.getRenderEngine()
+        is_gpu = current_engine in [lux.RENDER_ENGINE_PRODUCT_GPU, lux.RENDER_ENGINE_INTERIOR_GPU]
+        self.render_kwargs["current_device"] = "GPU" if is_gpu else "CPU"
 
-        engine_map = {
-            lux.RENDER_ENGINE_PRODUCT: lux.RENDER_ENGINE_PRODUCT_GPU,
-            lux.RENDER_ENGINE_INTERIOR: lux.RENDER_ENGINE_INTERIOR_GPU,
-            lux.RENDER_ENGINE_PRODUCT_GPU: lux.RENDER_ENGINE_PRODUCT,
-            lux.RENDER_ENGINE_INTERIOR_GPU: lux.RENDER_ENGINE_INTERIOR,
-        }
+        if not override_render_device:
+            self.render_kwargs["render_device"] = "GPU" if is_gpu else "CPU"
+        else:
+            self.render_kwargs["render_device"] = data["render_device"]
 
         if self.render_kwargs["render_device"] == "GPU":
             try:
-                if current_engine in [lux.RENDER_ENGINE_PRODUCT, lux.RENDER_ENGINE_INTERIOR]:
-                    lux.setRenderEngine(engine_map[current_engine])
+                if not is_gpu:
+                    engine_map = {
+                        lux.RENDER_ENGINE_PRODUCT: lux.RENDER_ENGINE_PRODUCT_GPU,
+                        lux.RENDER_ENGINE_INTERIOR: lux.RENDER_ENGINE_INTERIOR_GPU,
+                    }
+                    if current_engine in engine_map:
+                        lux.setRenderEngine(engine_map[current_engine])
             except Exception:
                 raise RuntimeError(
                     "GPU rendering was requested but no compatible GPU is available on this worker. Please manually set min GPUs to 1 under 'Host requirements' in the KeyShot integrated submitter."
                 )
-        else:  # CPU
-            if current_engine in [lux.RENDER_ENGINE_PRODUCT_GPU, lux.RENDER_ENGINE_INTERIOR_GPU]:
+        elif override_render_device and self.render_kwargs["render_device"] == "CPU" and is_gpu:
+            engine_map = {
+                lux.RENDER_ENGINE_PRODUCT_GPU: lux.RENDER_ENGINE_PRODUCT,
+                lux.RENDER_ENGINE_INTERIOR_GPU: lux.RENDER_ENGINE_INTERIOR,
+            }
+            if current_engine in engine_map:
                 lux.setRenderEngine(engine_map[current_engine])

--- a/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_handler.py
+++ b/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_handler.py
@@ -25,7 +25,7 @@ class KeyShotHandler:
             "output_format": self.set_output_format,
             "frame": self.set_frame,
             "render_options": self.set_render_options,
-            "render_engine": self.set_render_engine,
+            "render_device": self.set_render_device,
             "start_render": self.start_render,
         }
         self.render_kwargs = {}
@@ -53,6 +53,10 @@ class KeyShotHandler:
         Raises:
             RuntimeError: .
         """
+
+        selected_render_device = self.render_kwargs["render_device"]
+        print(f"Selected render device: {selected_render_device}")
+
         print("Starting Render...")
         frame = self.render_kwargs["frame"]
 
@@ -127,20 +131,18 @@ class KeyShotHandler:
         if "render_options" in data:
             self.render_kwargs["render_options"] = data["render_options"]
 
-    def set_render_engine(self, data: dict) -> None:
+    def set_render_device(self, data: dict) -> None:
         """
         Sets the render engine (CPU or GPU) based on the parameter value.
 
         Args:
-            data (dict): The data given from the Adaptor. Keys expected: ['render_engine']
+            data (dict): The data given from the Adaptor. Keys expected: ['render_device']
 
         Raises:
             RuntimeError: If GPU rendering is requested but no compatible GPU is available
         """
-        if "render_engine" not in data:
-            return
+        self.render_kwargs["render_device"] = data["render_device"]
 
-        render_engine = data.get("render_engine")
         current_engine = lux.getRenderEngine()
 
         engine_map = {
@@ -150,14 +152,14 @@ class KeyShotHandler:
             lux.RENDER_ENGINE_INTERIOR_GPU: lux.RENDER_ENGINE_INTERIOR,
         }
 
-        if render_engine == "GPU":
-            if not lux.isGPUAvailable():
+        if self.render_kwargs["render_device"] == "GPU":
+            try:
+                if current_engine in [lux.RENDER_ENGINE_PRODUCT, lux.RENDER_ENGINE_INTERIOR]:
+                    lux.setRenderEngine(engine_map[current_engine])
+            except Exception:
                 raise RuntimeError(
-                    "GPU rendering was requested but no compatible GPU is available on this worker."
+                    "GPU rendering was requested but no compatible GPU is available on this worker. Please manually set min GPUs to 1 under 'Host requirements' in the KeyShot integrated submitter."
                 )
-
-            if current_engine in [lux.RENDER_ENGINE_PRODUCT, lux.RENDER_ENGINE_INTERIOR]:
-                lux.setRenderEngine(engine_map[current_engine])
         else:  # CPU
             if current_engine in [lux.RENDER_ENGINE_PRODUCT_GPU, lux.RENDER_ENGINE_INTERIOR_GPU]:
                 lux.setRenderEngine(engine_map[current_engine])

--- a/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_handler.py
+++ b/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_handler.py
@@ -25,6 +25,7 @@ class KeyShotHandler:
             "output_format": self.set_output_format,
             "frame": self.set_frame,
             "render_options": self.set_render_options,
+            "render_engine": self.set_render_engine,
             "start_render": self.start_render,
         }
         self.render_kwargs = {}
@@ -125,3 +126,38 @@ class KeyShotHandler:
         """
         if "render_options" in data:
             self.render_kwargs["render_options"] = data["render_options"]
+
+    def set_render_engine(self, data: dict) -> None:
+        """
+        Sets the render engine (CPU or GPU) based on the parameter value.
+
+        Args:
+            data (dict): The data given from the Adaptor. Keys expected: ['render_engine']
+
+        Raises:
+            RuntimeError: If GPU rendering is requested but no compatible GPU is available
+        """
+        if "render_engine" not in data:
+            return
+
+        render_engine = data.get("render_engine")
+        current_engine = lux.getRenderEngine()
+
+        engine_map = {
+            lux.RENDER_ENGINE_PRODUCT: lux.RENDER_ENGINE_PRODUCT_GPU,
+            lux.RENDER_ENGINE_INTERIOR: lux.RENDER_ENGINE_INTERIOR_GPU,
+            lux.RENDER_ENGINE_PRODUCT_GPU: lux.RENDER_ENGINE_PRODUCT,
+            lux.RENDER_ENGINE_INTERIOR_GPU: lux.RENDER_ENGINE_INTERIOR,
+        }
+
+        if render_engine == "GPU":
+            if not lux.isGPUAvailable():
+                raise RuntimeError(
+                    "GPU rendering was requested but no compatible GPU is available on this worker."
+                )
+
+            if current_engine in [lux.RENDER_ENGINE_PRODUCT, lux.RENDER_ENGINE_INTERIOR]:
+                lux.setRenderEngine(engine_map[current_engine])
+        else:  # CPU
+            if current_engine in [lux.RENDER_ENGINE_PRODUCT_GPU, lux.RENDER_ENGINE_INTERIOR_GPU]:
+                lux.setRenderEngine(engine_map[current_engine])

--- a/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
+++ b/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
@@ -114,6 +114,10 @@ def construct_job_template(filename: str) -> dict:
     # This transforms {"progressive_max_samples": 1000} to {progressive_max_samples: 1000}, for example
     render_options = re.sub(r'"([^"]+)":', r"\1:", json.dumps(lux.getRenderOptions().getDict()))
 
+    current_engine = lux.getRenderEngine()
+    is_gpu = current_engine in [lux.RENDER_ENGINE_PRODUCT_GPU, lux.RENDER_ENGINE_INTERIOR_GPU]
+    default_engine = "GPU" if is_gpu else "CPU"
+
     return {
         "specificationVersion": "jobtemplate-2023-09",
         "name": filename,
@@ -175,6 +179,18 @@ def construct_job_template(filename: str) -> dict:
                     "groupLabel": "KeyShot Settings",
                 },
             },
+            {
+                "name": "RenderEngine",
+                "type": "STRING",
+                "description": "The render engine to use (CPU or GPU).",
+                "allowedValues": ["CPU", "GPU"],
+                "default": default_engine,
+                "userInterface": {
+                    "control": "DROPDOWN_LIST",
+                    "label": "Render Engine",
+                    "groupLabel": "KeyShot Settings",
+                },
+            },
         ],
         "steps": [
             {
@@ -201,6 +217,7 @@ def construct_job_template(filename: str) -> dict:
                                         "scene_file: '{{Param.KeyShotFile}}'\n"
                                         "output_file_path: '{{Param.OutputFilePath}}'\n"
                                         "output_format: 'RENDER_OUTPUT_{{Param.OutputFormat}}'\n"
+                                        "render_engine: '{{Param.RenderEngine}}'\n"
                                         f"render_options: {render_options}\n"
                                     ),
                                 }
@@ -584,6 +601,20 @@ def create_bundle(
     else:
         settings.parameter_values.append({"name": "KeyShotFile", "value": scene_file})
 
+    render_engine = None
+    if not any(param["name"] == "RenderEngine" for param in settings.parameter_values):
+        current_engine = lux.getRenderEngine()
+        is_gpu = current_engine in [lux.RENDER_ENGINE_PRODUCT_GPU, lux.RENDER_ENGINE_INTERIOR_GPU]
+        render_engine = "GPU" if is_gpu else "CPU"
+        settings.parameter_values.append(
+            {"name": "RenderEngine", "value": "GPU" if is_gpu else "CPU"}
+        )
+    else:
+        for param in settings.parameter_values:
+            if param["name"] == "RenderEngine":
+                render_engine = param["value"]
+                break
+
     # Add default values for Conda
     major_version, minor_version = lux.getKeyShotDisplayVersion()
     settings.parameter_values.append(
@@ -597,6 +628,11 @@ def create_bundle(
     job_template = construct_job_template(scene_name)
     asset_references = construct_asset_references(settings)
     parameter_values = construct_parameter_values(settings)
+
+    if render_engine == "GPU":
+        job_template["steps"][0]["hostRequirements"]["amounts"] = [
+            {"name": "amount.worker.gpu", "min": 1}
+        ]
 
     dump_json_to_dir(job_template, bundle_dir, "template.json")
     dump_json_to_dir(asset_references, bundle_dir, "asset_references.json")

--- a/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
+++ b/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
@@ -178,6 +178,18 @@ def construct_job_template(filename: str) -> dict:
                 },
             },
             {
+                "name": "OverrideRenderDevice",
+                "type": "STRING",
+                "description": "Whether to override the render device set in KeyShot.",
+                "allowedValues": ["TRUE", "FALSE"],
+                "default": "FALSE",
+                "userInterface": {
+                    "control": "CHECK_BOX",
+                    "label": "Override KeyShot render device",
+                    "groupLabel": "KeyShot Settings",
+                },
+            },
+            {
                 "name": "RenderDevice",
                 "type": "STRING",
                 "description": "The render device to use (CPU or GPU).",
@@ -215,6 +227,7 @@ def construct_job_template(filename: str) -> dict:
                                         "scene_file: '{{Param.KeyShotFile}}'\n"
                                         "output_file_path: '{{Param.OutputFilePath}}'\n"
                                         "output_format: 'RENDER_OUTPUT_{{Param.OutputFormat}}'\n"
+                                        "override_render_device: {{Param.OverrideRenderDevice}}\n"
                                         "render_device: '{{Param.RenderDevice}}'\n"
                                         f"render_options: {render_options}\n"
                                     ),
@@ -410,7 +423,7 @@ def options_dialog(show_gui=True) -> dict[str, Any]:
             "What files would you like to attach to the job?",
             0,
             [BIP_AND_REFERENCES, ONLY_BIP],
-        )
+        ),
     ]
     selections = lux.getInputDialog(
         title="AWS Deadline Cloud Submission Options",
@@ -599,15 +612,38 @@ def create_bundle(
     else:
         settings.parameter_values.append({"name": "KeyShotFile", "value": scene_file})
 
-    render_device = None
-    if not any(param["name"] == "RenderDevice" for param in settings.parameter_values):
+    override_enabled = False
+    for param in settings.parameter_values:
+        if param["name"] == "OverrideRenderDevice":
+            override_enabled = param["value"] == "TRUE"
+            break
+
+    if not any(param["name"] == "OverrideRenderDevice" for param in settings.parameter_values):
+        settings.parameter_values.append({"name": "OverrideRenderDevice", "value": "FALSE"})
+        override_enabled = False
+
+    if not override_enabled:
         render_device = get_current_render_device()
-        settings.parameter_values.append({"name": "RenderDevice", "value": render_device})
+
+        render_device_found = False
+        for param in settings.parameter_values:
+            if param["name"] == "RenderDevice":
+                param["value"] = render_device
+                render_device_found = True
+                break
+
+        if not render_device_found:
+            settings.parameter_values.append({"name": "RenderDevice", "value": render_device})
     else:
+        render_device = None
         for param in settings.parameter_values:
             if param["name"] == "RenderDevice":
                 render_device = param["value"]
                 break
+
+        if render_device is None:
+            render_device = get_current_render_device()
+            settings.parameter_values.append({"name": "RenderDevice", "value": render_device})
 
     # Add default values for Conda
     major_version, minor_version = lux.getKeyShotDisplayVersion()
@@ -623,7 +659,8 @@ def create_bundle(
     asset_references = construct_asset_references(settings)
     parameter_values = construct_parameter_values(settings)
 
-    if render_device == "GPU":
+    # Add GPU requirements if needed
+    if override_enabled and render_device == "GPU":
         job_template["steps"][0]["hostRequirements"]["amounts"] = [
             {"name": "amount.worker.gpu", "min": 1}
         ]

--- a/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
+++ b/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
@@ -114,9 +114,7 @@ def construct_job_template(filename: str) -> dict:
     # This transforms {"progressive_max_samples": 1000} to {progressive_max_samples: 1000}, for example
     render_options = re.sub(r'"([^"]+)":', r"\1:", json.dumps(lux.getRenderOptions().getDict()))
 
-    current_engine = lux.getRenderEngine()
-    is_gpu = current_engine in [lux.RENDER_ENGINE_PRODUCT_GPU, lux.RENDER_ENGINE_INTERIOR_GPU]
-    default_engine = "GPU" if is_gpu else "CPU"
+    default_device = get_current_render_device()
 
     return {
         "specificationVersion": "jobtemplate-2023-09",
@@ -180,14 +178,14 @@ def construct_job_template(filename: str) -> dict:
                 },
             },
             {
-                "name": "RenderEngine",
+                "name": "RenderDevice",
                 "type": "STRING",
-                "description": "The render engine to use (CPU or GPU).",
+                "description": "The render device to use (CPU or GPU).",
                 "allowedValues": ["CPU", "GPU"],
-                "default": default_engine,
+                "default": default_device,
                 "userInterface": {
                     "control": "DROPDOWN_LIST",
-                    "label": "Render Engine",
+                    "label": "Render Device (For GPU: must set host requirement min GPUs to 1)",
                     "groupLabel": "KeyShot Settings",
                 },
             },
@@ -217,7 +215,7 @@ def construct_job_template(filename: str) -> dict:
                                         "scene_file: '{{Param.KeyShotFile}}'\n"
                                         "output_file_path: '{{Param.OutputFilePath}}'\n"
                                         "output_format: 'RENDER_OUTPUT_{{Param.OutputFormat}}'\n"
-                                        "render_engine: '{{Param.RenderEngine}}'\n"
+                                        "render_device: '{{Param.RenderDevice}}'\n"
                                         f"render_options: {render_options}\n"
                                     ),
                                 }
@@ -601,18 +599,14 @@ def create_bundle(
     else:
         settings.parameter_values.append({"name": "KeyShotFile", "value": scene_file})
 
-    render_engine = None
-    if not any(param["name"] == "RenderEngine" for param in settings.parameter_values):
-        current_engine = lux.getRenderEngine()
-        is_gpu = current_engine in [lux.RENDER_ENGINE_PRODUCT_GPU, lux.RENDER_ENGINE_INTERIOR_GPU]
-        render_engine = "GPU" if is_gpu else "CPU"
-        settings.parameter_values.append(
-            {"name": "RenderEngine", "value": "GPU" if is_gpu else "CPU"}
-        )
+    render_device = None
+    if not any(param["name"] == "RenderDevice" for param in settings.parameter_values):
+        render_device = get_current_render_device()
+        settings.parameter_values.append({"name": "RenderDevice", "value": render_device})
     else:
         for param in settings.parameter_values:
-            if param["name"] == "RenderEngine":
-                render_engine = param["value"]
+            if param["name"] == "RenderDevice":
+                render_device = param["value"]
                 break
 
     # Add default values for Conda
@@ -629,7 +623,7 @@ def create_bundle(
     asset_references = construct_asset_references(settings)
     parameter_values = construct_parameter_values(settings)
 
-    if render_engine == "GPU":
+    if render_device == "GPU":
         job_template["steps"][0]["hostRequirements"]["amounts"] = [
             {"name": "amount.worker.gpu", "min": 1}
         ]
@@ -637,6 +631,12 @@ def create_bundle(
     dump_json_to_dir(job_template, bundle_dir, "template.json")
     dump_json_to_dir(asset_references, bundle_dir, "asset_references.json")
     dump_json_to_dir(parameter_values, bundle_dir, "parameter_values.json")
+
+
+def get_current_render_device() -> str:
+    current_engine = lux.getRenderEngine()
+    is_gpu = current_engine in [lux.RENDER_ENGINE_PRODUCT_GPU, lux.RENDER_ENGINE_INTERIOR_GPU]
+    return "GPU" if is_gpu else "CPU"
 
 
 if __name__ == "__main__":

--- a/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
+++ b/src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py
@@ -616,11 +616,10 @@ def create_bundle(
     for param in settings.parameter_values:
         if param["name"] == "OverrideRenderDevice":
             override_enabled = param["value"] == "TRUE"
+            override_param_found = True
             break
-
-    if not any(param["name"] == "OverrideRenderDevice" for param in settings.parameter_values):
+    if not override_param_found:
         settings.parameter_values.append({"name": "OverrideRenderDevice", "value": "FALSE"})
-        override_enabled = False
 
     if not override_enabled:
         render_device = get_current_render_device()

--- a/test/integ/cube/expected_bundle/parameter_values.json
+++ b/test/integ/cube/expected_bundle/parameter_values.json
@@ -18,7 +18,7 @@
         },
         {
             "name": "OverrideRenderDevice",
-            "value": "TRUE"
+            "value": "FALSE"
         },
         {
             "name": "KeyShotFile",

--- a/test/integ/cube/expected_bundle/parameter_values.json
+++ b/test/integ/cube/expected_bundle/parameter_values.json
@@ -13,7 +13,7 @@
             "value": "PNG"
         },
         {
-            "name": "RenderEngine",
+            "name": "RenderDevice",
             "value": "CPU"
         },
         {

--- a/test/integ/cube/expected_bundle/parameter_values.json
+++ b/test/integ/cube/expected_bundle/parameter_values.json
@@ -13,6 +13,10 @@
             "value": "PNG"
         },
         {
+            "name": "RenderEngine",
+            "value": "CPU"
+        },
+        {
             "name": "KeyShotFile",
             "value": "PATH_TO_BE_REPLACED\\deadline-cloud-for-keyshot\\test\\integ\\cube\\actual_bundle\\unpack\\scene.bip"
         },

--- a/test/integ/cube/expected_bundle/parameter_values.json
+++ b/test/integ/cube/expected_bundle/parameter_values.json
@@ -17,6 +17,10 @@
             "value": "CPU"
         },
         {
+            "name": "OverrideRenderDevice",
+            "value": "TRUE"
+        },
+        {
             "name": "KeyShotFile",
             "value": "PATH_TO_BE_REPLACED\\deadline-cloud-for-keyshot\\test\\integ\\cube\\actual_bundle\\unpack\\scene.bip"
         },

--- a/test/integ/cube/expected_bundle/template.json
+++ b/test/integ/cube/expected_bundle/template.json
@@ -60,6 +60,21 @@
             }
         },
         {
+            "name": "OverrideRenderDevice",
+            "type": "STRING",
+            "description": "Whether to override the render device set in KeyShot.",
+            "allowedValues": [
+                "TRUE",
+                "FALSE"
+            ],
+            "default": "FALSE",
+            "userInterface": {
+                "control": "CHECK_BOX",
+                "label": "Override KeyShot render device",
+                "groupLabel": "KeyShot Settings"
+            }
+        },
+        {
             "name": "RenderDevice",
             "type": "STRING",
             "description": "The render device to use (CPU or GPU).",
@@ -107,7 +122,7 @@
                                 "name": "initData",
                                 "filename": "init-data.yaml",
                                 "type": "TEXT",
-                                "data": "scene_file: '{{Param.KeyShotFile}}'\noutput_file_path: '{{Param.OutputFilePath}}'\noutput_format: 'RENDER_OUTPUT_{{Param.OutputFormat}}'\nrender_device: '{{Param.RenderDevice}}'\nrender_options: {add_to_queue: false, advanced_samples: 0, background_rendering: false, engine_anti_aliasing: 1, engine_caustics_quality: 0.0, engine_dof_quality: 3.0, engine_global_illumination: 0.0, engine_global_illumination_cache: true, engine_indirect_bounces: 1, engine_pixel_blur: 1.5, engine_ray_bounces: 6, engine_shadow_quality: 1.0, engine_sharp_shadows: true, engine_sharper_texture_filtering: false, engine_threads: 14, output_alpha_channel: false, output_ambient_occlusion_pass: false, output_caustics_pass: false, output_clown_pass: false, output_depth_pass: false, output_diffuse_pass: false, output_direct_lighting_pass: false, output_indirect_lighting_pass: false, output_labels_pass: false, output_normals_pass: false, output_raw_pass: false, output_reflection_pass: false, output_refraction_pass: false, output_render_layers: false, output_shadow_pass: false, progressive_max_samples: 0, progressive_max_time: 0.0, region: null, render_mode: 2, send_to_network: false, __VERSION: 5}\n"
+                                "data": "scene_file: '{{Param.KeyShotFile}}'\noutput_file_path: '{{Param.OutputFilePath}}'\noutput_format: 'RENDER_OUTPUT_{{Param.OutputFormat}}'\noverride_render_device: {{Param.OverrideRenderDevice}}\nrender_device: '{{Param.RenderDevice}}'\nrender_options: {add_to_queue: false, advanced_samples: 0, background_rendering: false, engine_anti_aliasing: 1, engine_caustics_quality: 0.0, engine_dof_quality: 3.0, engine_global_illumination: 0.0, engine_global_illumination_cache: true, engine_indirect_bounces: 1, engine_pixel_blur: 1.5, engine_ray_bounces: 6, engine_shadow_quality: 1.0, engine_sharp_shadows: true, engine_sharper_texture_filtering: false, engine_threads: 14, output_alpha_channel: false, output_ambient_occlusion_pass: false, output_caustics_pass: false, output_clown_pass: false, output_depth_pass: false, output_diffuse_pass: false, output_direct_lighting_pass: false, output_indirect_lighting_pass: false, output_labels_pass: false, output_normals_pass: false, output_raw_pass: false, output_reflection_pass: false, output_refraction_pass: false, output_render_layers: false, output_shadow_pass: false, progressive_max_samples: 0, progressive_max_time: 0.0, region: null, render_mode: 2, send_to_network: false, __VERSION: 5}\n"
                             }
                         ],
                         "actions": {

--- a/test/integ/cube/expected_bundle/template.json
+++ b/test/integ/cube/expected_bundle/template.json
@@ -60,9 +60,9 @@
             }
         },
         {
-            "name": "RenderEngine",
+            "name": "RenderDevice",
             "type": "STRING",
-            "description": "The render engine to use (CPU or GPU).",
+            "description": "The render device to use (CPU or GPU).",
             "allowedValues": [
                 "CPU",
                 "GPU"
@@ -70,7 +70,7 @@
             "default": "CPU",
             "userInterface": {
                 "control": "DROPDOWN_LIST",
-                "label": "Render Engine",
+                "label": "Render Device (For GPU: must set host requirement min GPUs to 1)",
                 "groupLabel": "KeyShot Settings"
             }
         }
@@ -107,7 +107,7 @@
                                 "name": "initData",
                                 "filename": "init-data.yaml",
                                 "type": "TEXT",
-                                "data": "scene_file: '{{Param.KeyShotFile}}'\noutput_file_path: '{{Param.OutputFilePath}}'\noutput_format: 'RENDER_OUTPUT_{{Param.OutputFormat}}'\nrender_engine: '{{Param.RenderEngine}}'\nrender_options: {add_to_queue: false, advanced_samples: 0, background_rendering: false, engine_anti_aliasing: 1, engine_caustics_quality: 0.0, engine_dof_quality: 3.0, engine_global_illumination: 0.0, engine_global_illumination_cache: true, engine_indirect_bounces: 1, engine_pixel_blur: 1.5, engine_ray_bounces: 6, engine_shadow_quality: 1.0, engine_sharp_shadows: true, engine_sharper_texture_filtering: false, engine_threads: 14, output_alpha_channel: false, output_ambient_occlusion_pass: false, output_caustics_pass: false, output_clown_pass: false, output_depth_pass: false, output_diffuse_pass: false, output_direct_lighting_pass: false, output_indirect_lighting_pass: false, output_labels_pass: false, output_normals_pass: false, output_raw_pass: false, output_reflection_pass: false, output_refraction_pass: false, output_render_layers: false, output_shadow_pass: false, progressive_max_samples: 0, progressive_max_time: 0.0, region: null, render_mode: 2, send_to_network: false, __VERSION: 5}\n"
+                                "data": "scene_file: '{{Param.KeyShotFile}}'\noutput_file_path: '{{Param.OutputFilePath}}'\noutput_format: 'RENDER_OUTPUT_{{Param.OutputFormat}}'\nrender_device: '{{Param.RenderDevice}}'\nrender_options: {add_to_queue: false, advanced_samples: 0, background_rendering: false, engine_anti_aliasing: 1, engine_caustics_quality: 0.0, engine_dof_quality: 3.0, engine_global_illumination: 0.0, engine_global_illumination_cache: true, engine_indirect_bounces: 1, engine_pixel_blur: 1.5, engine_ray_bounces: 6, engine_shadow_quality: 1.0, engine_sharp_shadows: true, engine_sharper_texture_filtering: false, engine_threads: 14, output_alpha_channel: false, output_ambient_occlusion_pass: false, output_caustics_pass: false, output_clown_pass: false, output_depth_pass: false, output_diffuse_pass: false, output_direct_lighting_pass: false, output_indirect_lighting_pass: false, output_labels_pass: false, output_normals_pass: false, output_raw_pass: false, output_reflection_pass: false, output_refraction_pass: false, output_render_layers: false, output_shadow_pass: false, progressive_max_samples: 0, progressive_max_time: 0.0, region: null, render_mode: 2, send_to_network: false, __VERSION: 5}\n"
                             }
                         ],
                         "actions": {

--- a/test/integ/cube/expected_bundle/template.json
+++ b/test/integ/cube/expected_bundle/template.json
@@ -58,6 +58,21 @@
                 "label": "Output Format (must match file extension)",
                 "groupLabel": "KeyShot Settings"
             }
+        },
+        {
+            "name": "RenderEngine",
+            "type": "STRING",
+            "description": "The render engine to use (CPU or GPU).",
+            "allowedValues": [
+                "CPU",
+                "GPU"
+            ],
+            "default": "CPU",
+            "userInterface": {
+                "control": "DROPDOWN_LIST",
+                "label": "Render Engine",
+                "groupLabel": "KeyShot Settings"
+            }
         }
     ],
     "steps": [
@@ -92,7 +107,7 @@
                                 "name": "initData",
                                 "filename": "init-data.yaml",
                                 "type": "TEXT",
-                                "data": "scene_file: '{{Param.KeyShotFile}}'\noutput_file_path: '{{Param.OutputFilePath}}'\noutput_format: 'RENDER_OUTPUT_{{Param.OutputFormat}}'\nrender_options: {add_to_queue: false, advanced_samples: 0, background_rendering: false, engine_anti_aliasing: 1, engine_caustics_quality: 0.0, engine_dof_quality: 3.0, engine_global_illumination: 0.0, engine_global_illumination_cache: true, engine_indirect_bounces: 1, engine_pixel_blur: 1.5, engine_ray_bounces: 6, engine_shadow_quality: 1.0, engine_sharp_shadows: true, engine_sharper_texture_filtering: false, engine_threads: 14, output_alpha_channel: false, output_ambient_occlusion_pass: false, output_caustics_pass: false, output_clown_pass: false, output_depth_pass: false, output_diffuse_pass: false, output_direct_lighting_pass: false, output_indirect_lighting_pass: false, output_labels_pass: false, output_normals_pass: false, output_raw_pass: false, output_reflection_pass: false, output_refraction_pass: false, output_render_layers: false, output_shadow_pass: false, progressive_max_samples: 0, progressive_max_time: 0.0, region: null, render_mode: 2, send_to_network: false, __VERSION: 5}\n"
+                                "data": "scene_file: '{{Param.KeyShotFile}}'\noutput_file_path: '{{Param.OutputFilePath}}'\noutput_format: 'RENDER_OUTPUT_{{Param.OutputFormat}}'\nrender_engine: '{{Param.RenderEngine}}'\nrender_options: {add_to_queue: false, advanced_samples: 0, background_rendering: false, engine_anti_aliasing: 1, engine_caustics_quality: 0.0, engine_dof_quality: 3.0, engine_global_illumination: 0.0, engine_global_illumination_cache: true, engine_indirect_bounces: 1, engine_pixel_blur: 1.5, engine_ray_bounces: 6, engine_shadow_quality: 1.0, engine_sharp_shadows: true, engine_sharper_texture_filtering: false, engine_threads: 14, output_alpha_channel: false, output_ambient_occlusion_pass: false, output_caustics_pass: false, output_clown_pass: false, output_depth_pass: false, output_diffuse_pass: false, output_direct_lighting_pass: false, output_indirect_lighting_pass: false, output_labels_pass: false, output_normals_pass: false, output_raw_pass: false, output_reflection_pass: false, output_refraction_pass: false, output_render_layers: false, output_shadow_pass: false, progressive_max_samples: 0, progressive_max_time: 0.0, region: null, render_mode: 2, send_to_network: false, __VERSION: 5}\n"
                             }
                         ],
                         "actions": {

--- a/test/unit/keyshot_adaptor/KeyShotAdaptor/test_adaptor.py
+++ b/test/unit/keyshot_adaptor/KeyShotAdaptor/test_adaptor.py
@@ -26,6 +26,7 @@ CURRENT_INIT_DATA_SCHEMA = {
                 "RENDER_OUTPUT_PSD32",
             ]
         },
+        "render_engine": {"enum": ["CPU", "GPU"]},
         "render_options": {"type": "object"},
     },
     "required": ["scene_file"],
@@ -85,7 +86,7 @@ def test_if_init_data_and_run_data_schema_are_changed_schema_version_is_bumped(i
     # if init_data.schema.json or run_data.schema.json are changed, these must
     # also be bumped
     assert semantic_version.major == 0
-    assert semantic_version.minor == 2
+    assert semantic_version.minor == 3
 
 
 def test_adaptor_prints_version_on_init(init_data, capfd):

--- a/test/unit/keyshot_adaptor/KeyShotAdaptor/test_adaptor.py
+++ b/test/unit/keyshot_adaptor/KeyShotAdaptor/test_adaptor.py
@@ -27,6 +27,7 @@ CURRENT_INIT_DATA_SCHEMA = {
             ]
         },
         "render_device": {"enum": ["CPU", "GPU"]},
+        "override_render_device": {"type": "boolean"},
         "render_options": {"type": "object"},
     },
     "required": ["scene_file"],

--- a/test/unit/keyshot_adaptor/KeyShotAdaptor/test_adaptor.py
+++ b/test/unit/keyshot_adaptor/KeyShotAdaptor/test_adaptor.py
@@ -26,7 +26,7 @@ CURRENT_INIT_DATA_SCHEMA = {
                 "RENDER_OUTPUT_PSD32",
             ]
         },
-        "render_engine": {"enum": ["CPU", "GPU"]},
+        "render_device": {"enum": ["CPU", "GPU"]},
         "render_options": {"type": "object"},
     },
     "required": ["scene_file"],
@@ -86,7 +86,7 @@ def test_if_init_data_and_run_data_schema_are_changed_schema_version_is_bumped(i
     # if init_data.schema.json or run_data.schema.json are changed, these must
     # also be bumped
     assert semantic_version.major == 0
-    assert semantic_version.minor == 3
+    assert semantic_version.minor == 2
 
 
 def test_adaptor_prints_version_on_init(init_data, capfd):

--- a/test/unit/keyshot_adaptor/KeyShotClient/test_keyshot_handler.py
+++ b/test/unit/keyshot_adaptor/KeyShotClient/test_keyshot_handler.py
@@ -6,14 +6,19 @@ from unittest import mock
 
 import pytest
 
+RENDER_ENGINE_PRODUCT = 0
+RENDER_ENGINE_INTERIOR = 1
+RENDER_ENGINE_PRODUCT_GPU = 2
+RENDER_ENGINE_INTERIOR_GPU = 3
+
 
 @pytest.fixture(autouse=True)
 def setup_engine_constants():
     """Set up the engine constants for all tests."""
-    lux.RENDER_ENGINE_PRODUCT = 0
-    lux.RENDER_ENGINE_INTERIOR = 1
-    lux.RENDER_ENGINE_PRODUCT_GPU = 2
-    lux.RENDER_ENGINE_INTERIOR_GPU = 3
+    lux.RENDER_ENGINE_PRODUCT = RENDER_ENGINE_PRODUCT
+    lux.RENDER_ENGINE_INTERIOR = RENDER_ENGINE_INTERIOR
+    lux.RENDER_ENGINE_PRODUCT_GPU = RENDER_ENGINE_PRODUCT_GPU
+    lux.RENDER_ENGINE_INTERIOR_GPU = RENDER_ENGINE_INTERIOR_GPU
     yield
 
 
@@ -41,6 +46,7 @@ def test_start_render_uses_passed_render_options():
         handler.render_kwargs = {
             "render_options": {"engine_anti_aliasing": 1, "progressive_max_samples": 10},
             "frame": 1,
+            "render_device": "CPU",
         }
         handler.output_path = "test_%d.png"
 
@@ -52,44 +58,25 @@ def test_start_render_uses_passed_render_options():
         )
 
 
-def test_set_render_engine_gpu_with_gpu_available():
+def test_set_render_device_gpu_with_gpu_available():
     with (
-        mock.patch.object(lux, "isGPUAvailable", return_value=True),
         mock.patch.object(lux, "getRenderEngine", return_value=0),
-        mock.patch.object(lux, "setRenderEngine") as set_render_engine_mock,
+        mock.patch.object(lux, "setRenderEngine") as set_render_device_mock,
     ):
 
         handler = KeyShotHandler()
-        handler.set_render_engine({"render_engine": "GPU"})
+        handler.set_render_device({"render_device": "GPU"})
 
-        set_render_engine_mock.assert_called_once_with(2)
+        set_render_device_mock.assert_called_once_with(RENDER_ENGINE_PRODUCT_GPU)
 
 
-def test_set_render_engine_gpu_with_no_gpu_available():
+def test_set_render_device_cpu_with_gpu_engine():
     with (
-        mock.patch.object(lux, "isGPUAvailable", return_value=False),
-        mock.patch.object(lux, "getRenderEngine", return_value=0),
-        mock.patch.object(lux, "setRenderEngine") as set_render_engine_mock,
+        mock.patch.object(lux, "getRenderEngine", return_value=RENDER_ENGINE_PRODUCT_GPU),
+        mock.patch.object(lux, "setRenderEngine") as set_render_device_mock,
     ):
 
         handler = KeyShotHandler()
+        handler.set_render_device({"render_device": "CPU"})
 
-        with pytest.raises(RuntimeError) as context:
-            handler.set_render_engine({"render_engine": "GPU"})
-
-        assert "GPU rendering was requested but no compatible GPU is available" in str(
-            context.value
-        )
-        set_render_engine_mock.assert_not_called()
-
-
-def test_set_render_engine_cpu_with_gpu_engine():
-    with (
-        mock.patch.object(lux, "getRenderEngine", return_value=2),
-        mock.patch.object(lux, "setRenderEngine") as set_render_engine_mock,
-    ):
-
-        handler = KeyShotHandler()
-        handler.set_render_engine({"render_engine": "CPU"})
-
-        set_render_engine_mock.assert_called_once_with(0)
+        set_render_device_mock.assert_called_once_with(RENDER_ENGINE_PRODUCT)

--- a/test/unit/keyshot_adaptor/KeyShotClient/test_keyshot_handler.py
+++ b/test/unit/keyshot_adaptor/KeyShotClient/test_keyshot_handler.py
@@ -4,6 +4,18 @@ from ... import lux_import_override  # noqa: F401
 from deadline.keyshot_adaptor.KeyShotClient.keyshot_handler import KeyShotHandler, lux
 from unittest import mock
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def setup_engine_constants():
+    """Set up the engine constants for all tests."""
+    lux.RENDER_ENGINE_PRODUCT = 0
+    lux.RENDER_ENGINE_INTERIOR = 1
+    lux.RENDER_ENGINE_PRODUCT_GPU = 2
+    lux.RENDER_ENGINE_INTERIOR_GPU = 3
+    yield
+
 
 def test_keyshot_handler_creation():
     KeyShotHandler()
@@ -38,3 +50,46 @@ def test_start_render_uses_passed_render_options():
         render_image_mock.assert_called_once_with(
             path="test_1.png", opts=mock_render_options_obj, format=mock.ANY
         )
+
+
+def test_set_render_engine_gpu_with_gpu_available():
+    with (
+        mock.patch.object(lux, "isGPUAvailable", return_value=True),
+        mock.patch.object(lux, "getRenderEngine", return_value=0),
+        mock.patch.object(lux, "setRenderEngine") as set_render_engine_mock,
+    ):
+
+        handler = KeyShotHandler()
+        handler.set_render_engine({"render_engine": "GPU"})
+
+        set_render_engine_mock.assert_called_once_with(2)
+
+
+def test_set_render_engine_gpu_with_no_gpu_available():
+    with (
+        mock.patch.object(lux, "isGPUAvailable", return_value=False),
+        mock.patch.object(lux, "getRenderEngine", return_value=0),
+        mock.patch.object(lux, "setRenderEngine") as set_render_engine_mock,
+    ):
+
+        handler = KeyShotHandler()
+
+        with pytest.raises(RuntimeError) as context:
+            handler.set_render_engine({"render_engine": "GPU"})
+
+        assert "GPU rendering was requested but no compatible GPU is available" in str(
+            context.value
+        )
+        set_render_engine_mock.assert_not_called()
+
+
+def test_set_render_engine_cpu_with_gpu_engine():
+    with (
+        mock.patch.object(lux, "getRenderEngine", return_value=2),
+        mock.patch.object(lux, "setRenderEngine") as set_render_engine_mock,
+    ):
+
+        handler = KeyShotHandler()
+        handler.set_render_engine({"render_engine": "CPU"})
+
+        set_render_engine_mock.assert_called_once_with(0)

--- a/test/unit/keyshot_adaptor/KeyShotClient/test_keyshot_handler.py
+++ b/test/unit/keyshot_adaptor/KeyShotClient/test_keyshot_handler.py
@@ -8,8 +8,8 @@ import pytest
 
 RENDER_ENGINE_PRODUCT = 0
 RENDER_ENGINE_INTERIOR = 1
-RENDER_ENGINE_PRODUCT_GPU = 2
-RENDER_ENGINE_INTERIOR_GPU = 3
+RENDER_ENGINE_PRODUCT_GPU = 3
+RENDER_ENGINE_INTERIOR_GPU = 4
 
 
 @pytest.fixture(autouse=True)
@@ -40,6 +40,7 @@ def test_start_render_uses_passed_render_options():
         mock.patch.object(lux, "setAnimationFrame"),
         mock.patch.object(lux, "getRenderOptions") as get_render_options_mock,
         mock.patch.object(lux, "RenderOptions", return_value=mock_render_options_obj),
+        mock.patch.object(lux, "getRenderEngine", return_value=0),
     ):
 
         handler = KeyShotHandler()
@@ -47,6 +48,8 @@ def test_start_render_uses_passed_render_options():
             "render_options": {"engine_anti_aliasing": 1, "progressive_max_samples": 10},
             "frame": 1,
             "render_device": "CPU",
+            "override_render_device": False,
+            "current_device": "CPU",
         }
         handler.output_path = "test_%d.png"
 
@@ -65,6 +68,7 @@ def test_set_render_device_gpu_with_gpu_available():
     ):
 
         handler = KeyShotHandler()
+        handler.render_kwargs = {"override_render_device": True}
         handler.set_render_device({"render_device": "GPU"})
 
         set_render_device_mock.assert_called_once_with(RENDER_ENGINE_PRODUCT_GPU)
@@ -77,6 +81,21 @@ def test_set_render_device_cpu_with_gpu_engine():
     ):
 
         handler = KeyShotHandler()
+        handler.render_kwargs = {"override_render_device": True}
         handler.set_render_device({"render_device": "CPU"})
 
         set_render_device_mock.assert_called_once_with(RENDER_ENGINE_PRODUCT)
+
+
+def test_set_render_device_with_override_false():
+    with (
+        mock.patch.object(lux, "getRenderEngine", return_value=RENDER_ENGINE_PRODUCT),
+        mock.patch.object(lux, "setRenderEngine") as set_render_device_mock,
+    ):
+
+        handler = KeyShotHandler()
+        handler.render_kwargs = {"override_render_device": False}
+        handler.set_render_device({"render_device": "GPU"})
+
+        set_render_device_mock.assert_not_called()
+        assert handler.render_kwargs["render_device"] == "CPU"

--- a/test/unit/keyshot_submitter/test_keyshot_submitter.py
+++ b/test/unit/keyshot_submitter/test_keyshot_submitter.py
@@ -397,3 +397,30 @@ def test_construct_job_template_timeout_values():
 
     assert actions["onEnter"]["timeout"] == submitter.KEYSHOT_ENVIRON_ENTER_TIMEOUT
     assert actions["onExit"]["timeout"] == submitter.KEYSHOT_ENVIRON_EXIT_TIMEOUT
+
+
+def test_construct_job_template_includes_render_engine_parameter():
+    with mock.patch.object(submitter.lux, "getRenderEngine") as get_render_engine_mock:
+        submitter.lux.RENDER_ENGINE_PRODUCT_GPU = 1
+        submitter.lux.RENDER_ENGINE_INTERIOR_GPU = 2
+
+        get_render_engine_mock.return_value = 0
+        template_cpu = submitter.construct_job_template("test_scene")
+
+        get_render_engine_mock.return_value = 1
+        template_gpu = submitter.construct_job_template("test_scene")
+
+        render_engine_param_cpu = next(
+            (p for p in template_cpu["parameterDefinitions"] if p["name"] == "RenderEngine"), None
+        )
+        render_engine_param_gpu = next(
+            (p for p in template_gpu["parameterDefinitions"] if p["name"] == "RenderEngine"), None
+        )
+
+        assert render_engine_param_cpu is not None
+        assert render_engine_param_cpu["default"] == "CPU"
+        assert render_engine_param_cpu["allowedValues"] == ["CPU", "GPU"]
+
+        assert render_engine_param_gpu is not None
+        assert render_engine_param_gpu["default"] == "GPU"
+        assert render_engine_param_gpu["allowedValues"] == ["CPU", "GPU"]

--- a/test/unit/keyshot_submitter/test_keyshot_submitter.py
+++ b/test/unit/keyshot_submitter/test_keyshot_submitter.py
@@ -14,6 +14,11 @@ from .. import lux_import_override  # noqa F401
 deadline = __import__("deadline.keyshot_submitter.Submit to AWS Deadline Cloud")
 submitter = getattr(deadline.keyshot_submitter, "Submit to AWS Deadline Cloud")
 
+RENDER_ENGINE_PRODUCT = 0
+RENDER_ENGINE_INTERIOR = 1
+RENDER_ENGINE_PRODUCT_GPU = 2
+RENDER_ENGINE_INTERIOR_GPU = 3
+
 
 @pytest.fixture
 def mock_lux_is_scene_changed():
@@ -399,28 +404,28 @@ def test_construct_job_template_timeout_values():
     assert actions["onExit"]["timeout"] == submitter.KEYSHOT_ENVIRON_EXIT_TIMEOUT
 
 
-def test_construct_job_template_includes_render_engine_parameter():
-    with mock.patch.object(submitter.lux, "getRenderEngine") as get_render_engine_mock:
-        submitter.lux.RENDER_ENGINE_PRODUCT_GPU = 1
-        submitter.lux.RENDER_ENGINE_INTERIOR_GPU = 2
+def test_construct_job_template_includes_render_device_parameter():
+    with mock.patch.object(submitter.lux, "getRenderEngine") as get_render_device_mock:
+        submitter.lux.RENDER_ENGINE_PRODUCT_GPU = RENDER_ENGINE_PRODUCT_GPU
+        submitter.lux.RENDER_ENGINE_INTERIOR_GPU = RENDER_ENGINE_INTERIOR_GPU
 
-        get_render_engine_mock.return_value = 0
+        get_render_device_mock.return_value = RENDER_ENGINE_PRODUCT
         template_cpu = submitter.construct_job_template("test_scene")
 
-        get_render_engine_mock.return_value = 1
+        get_render_device_mock.return_value = RENDER_ENGINE_PRODUCT_GPU
         template_gpu = submitter.construct_job_template("test_scene")
 
-        render_engine_param_cpu = next(
-            (p for p in template_cpu["parameterDefinitions"] if p["name"] == "RenderEngine"), None
+        render_device_param_cpu = next(
+            (p for p in template_cpu["parameterDefinitions"] if p["name"] == "RenderDevice"), None
         )
-        render_engine_param_gpu = next(
-            (p for p in template_gpu["parameterDefinitions"] if p["name"] == "RenderEngine"), None
+        render_device_param_gpu = next(
+            (p for p in template_gpu["parameterDefinitions"] if p["name"] == "RenderDevice"), None
         )
 
-        assert render_engine_param_cpu is not None
-        assert render_engine_param_cpu["default"] == "CPU"
-        assert render_engine_param_cpu["allowedValues"] == ["CPU", "GPU"]
+        assert render_device_param_cpu is not None
+        assert render_device_param_cpu["default"] == "CPU"
+        assert render_device_param_cpu["allowedValues"] == ["CPU", "GPU"]
 
-        assert render_engine_param_gpu is not None
-        assert render_engine_param_gpu["default"] == "GPU"
-        assert render_engine_param_gpu["allowedValues"] == ["CPU", "GPU"]
+        assert render_device_param_gpu is not None
+        assert render_device_param_gpu["default"] == "GPU"
+        assert render_device_param_gpu["allowedValues"] == ["CPU", "GPU"]


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-keyshot/issues/151

### What was the problem/requirement? (What/Why)
When users are working on a CPU-only workstation, KeyShot's interface only allows them to select CPU rendering options. This limitation prevents users from configuring GPU rendering jobs for AWS Deadline Cloud, even though the cloud workers might have GPUs available. We need to enhance the AWS Deadline Cloud submission process to allow users to select GPU rendering regardless of their local hardware capabilities. This way, users on CPU-only workstations can still take advantage of GPU rendering. Also, if a GPU render is submitted, a minimum of 1 GPU is not added to the host requirements, so the job could be assigned to the wrong fleet unless the user also selects a minimum of 1 GPU in the host requirements tab.

### What was the solution? (How)
I added a "RenderEngine" parameter to the job template that allows users to select either CPU or GPU rendering, regardless of their local hardware. When GPU is selected, I automatically add a GPU requirement to the job template, ensuring the job is assigned to a worker with GPU capabilities. I also implemented error handling to provide clear messages if a job is assigned to a worker without the required GPU.

### What is the impact of this change?
This change enables users on CPU-only workstations to submit GPU rendering jobs to AWS Deadline Cloud, allowing them to leverage cloud GPU resources for faster rendering. It also ensures jobs are properly routed to workers with the required hardware capabilities, preventing failed renders and improving overall workflow efficiency. Users will now have more flexibility in their rendering options regardless of their local hardware limitations.

### How was this change tested?
I wrote and ran unit tests, I ran integration tests with hatch, and I ran it in my own Conda environment with both the GPU option and the CPU option. The result was that the GPU run was faster than the CPU. For a max sample value of 25, the CPU run took 8:37 minutes while the GPU run took 1:48 minutes for the same frame with the same worker, which goes in line with what we were expected because GPU renders should be faster if all other conditions remain the same. The submitter GUI change is also visible.

### Was this change documented?
N/A

### Is this a breaking change?
Yes

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
