### PR TITLE
fix: Add error handling for KeyShot version compatibility issues

### DIFF
--- a/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_handler.py
+++ b/src/deadline/keyshot_adaptor/KeyShotClient/keyshot_handler.py
@@ -104,7 +104,15 @@ class KeyShotHandler:
         output_path = self.output_path.replace("%d", str(frame))
         pprint(f"KeyShot Render Options: {opts}", indent=4)
         print(f"KeyShot Render Output Format: {self.output_format_code}")
-        lux.renderImage(path=output_path, opts=opts, format=self.output_format_code)
+
+        try:
+            lux.renderImage(path=output_path, opts=opts, format=self.output_format_code)
+        except Exception as e:
+            error_message = str(e)
+            if "This scene was saved using a newer version" in error_message:
+                print(f"WARNING: Version mismatch detected but continuing: {error_message}")
+            else:
+                raise
         print(f"Finished Rendering {output_path}")
 
     def set_output_format(self, data: dict) -> None:

--- a/test/integ/cube/expected_bundle/parameter_values.json
+++ b/test/integ/cube/expected_bundle/parameter_values.json
@@ -26,7 +26,7 @@
         },
         {
             "name": "CondaPackages",
-            "value": "keyshot=2024.* keyshot-openjd=0.3.*"
+            "value": "keyshot=2024.* keyshot-openjd=0.4.*"
         },
         {
             "name": "CondaChannels",

--- a/test/integ/helpers/test_runners.py
+++ b/test/integ/helpers/test_runners.py
@@ -180,7 +180,7 @@ def assert_expected_job_bundle_and_generated_job_bundle_are_equal(
                 # generalize to all versions of KeyShot and the adaptor
                 content2 = re.sub(
                     r"keyshot=202[3-9].\* keyshot-openjd=0.\d.\*",
-                    "keyshot=2024.* keyshot-openjd=0.3.*",
+                    "keyshot=2024.* keyshot-openjd=0.4.*",
                     content2,
                 )
 


### PR DESCRIPTION
Fixes: https://amzn-aws.slack.com/archives/C029PHQERN0/p1751567442931389

### What was the problem/requirement? (What/Why)
If a customer submits from KeyShot 2025 to our 2024 Conda package, they can get a failed render on KeyShot with the following:

```
2025/07/07 17:01:15-07:00 ADAPTOR_OUTPUT: STDOUT:     lux.renderImage(path=output_path, opts=opts, format=self.output_format_code)
2025/07/07 17:01:15-07:00 ADAPTOR_OUTPUT: STDOUT: Exception: This scene was saved using a newer version [14.0]. Opening it in an older version will cause some information to be lost.
2025/07/07 17:01:15-07:00 ADAPTOR_OUTPUT: STDOUT: We recommend updating to version [14.0] or later.
```

### What was the solution? (How)
Since the rendering was still complete, we could simply ignore this error, which is what I ended up doing.

### What is the impact of this change?
Maintains the potential customer workflow of submitting from KeyShot 2025 to our 2024 Conda package.

### How was this change tested?
Unit tests, integration tests, and using my own Conda packages.

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
