### PR TITLE
chore: add native dependency psutil to deps bundle

### DIFF
--- a/scripts/deps_bundle.py
+++ b/scripts/deps_bundle.py
@@ -13,7 +13,7 @@ from _project import get_project_dict, get_dependencies, get_pip_platform, Depen
 
 SUPPORTED_PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
 SUPPORTED_PLATFORMS = ["Windows", "Linux", "Darwin"]
-NATIVE_DEPENDENCIES = ["xxhash"]
+NATIVE_DEPENDENCIES = ["xxhash", "psutil"]
 
 
 def _get_package_version_regex(package: str) -> re.Pattern:


### PR DESCRIPTION
Fixes: N/A

### What was the problem/requirement? (What/Why)
We added a new dependency psutil to deadine-cloud https://github.com/aws-deadline/deadline-cloud/blob/e5176598cc859584217eaea00d5e6a14a40070d5/pyproject.toml#L47 for a new feature in experimental. This dependency has native components and needs to be added to deps bundle for every installer

### What was the solution? (How)
Added psutil to native dependencies for the feature to be supported.

### What is the impact of this change?
Bundling required dependencies for every submitter installer. For unreal there is no individual installer but we're doing this for consistency with other DCCs

### How was this change tested?
Built the installer and ran the tests
```
hatch run installer:build-installer --install-builder-path /Applications/InstallBuilder\ Enterprise\ 25.6.0 --output-dir . --local-dev
[07/16/25 10:40:18] WARNING  pyproject.toml does not contain a tool.setuptools_scm section                                                                                                                                             setuptools.py:119
Collecting black==25.* (from -r requirements-testing.txt (line 1))
  Using cached black-25.1.0-cp310-cp310-macosx_11_0_arm64.whl.metadata (81 kB)
Collecting coverage==7.* (from coverage[toml]==7.*->-r requirements-testing.txt (line 2))
  Using cached coverage-7.9.2-cp310-cp310-macosx_11_0_arm64.whl.metadata (8.9 kB)
Collecting mypy==1.* (from -r requirements-testing.txt (line 3))
  Using cached mypy-1.17.0-cp310-cp310-macosx_11_0_arm64.whl.metadata (2.2 kB)
Collecting numpy==2.* (from -r requirements-testing.txt (line 4))
  Using cached numpy-2.2.6-cp310-cp310-macosx_14_0_arm64.whl.metadata (62 kB)
Collecting pillow==11.* (from -r requirements-testing.txt (line 5))
  Using cached pillow-11.3.0-cp310-cp310-macosx_11_0_arm64.whl.metadata (9.0 kB)
Collecting pytest==8.* (from -r requirements-testing.txt (line 6))
  Using cached pytest-8.4.1-py3-none-any.whl.metadata (7.7 kB)
Collecting pytest-cov==6.* (from -r requirements-testing.txt (line 7))
  Using cached pytest_cov-6.2.1-py3-none-any.whl.metadata (30 kB)
Collecting pytest-xdist==3.* (from -r requirements-testing.txt (line 8))
  Using cached pytest_xdist-3.8.0-py3-none-any.whl.metadata (3.0 kB)
Collecting ruff==0.12.* (from -r requirements-testing.txt (line 9))
  Using cached ruff-0.12.3-py3-none-macosx_11_0_arm64.whl.metadata (25 kB)
Collecting types-pyyaml==6.* (from -r requirements-testing.txt (line 10))
  Using cached types_pyyaml-6.0.12.20250516-py3-none-any.whl.metadata (1.8 kB)
Collecting twine==6.* (from -r requirements-testing.txt (line 11))
  Using cached twine-6.1.0-py3-none-any.whl.metadata (3.7 kB)
Collecting click>=8.0.0 (from black==25.*->-r requirements-testing.txt (line 1))
  Using cached click-8.2.1-py3-none-any.whl.metadata (2.5 kB)
Collecting mypy-extensions>=0.4.3 (from black==25.*->-r requirements-testing.txt (line 1))
  Using cached mypy_extensions-1.1.0-py3-none-any.whl.metadata (1.1 kB)
Collecting packaging>=22.0 (from black==25.*->-r requirements-testing.txt (line 1))
  Using cached packaging-25.0-py3-none-any.whl.metadata (3.3 kB)
Collecting pathspec>=0.9.0 (from black==25.*->-r requirements-testing.txt (line 1))
  Using cached pathspec-0.12.1-py3-none-any.whl.metadata (21 kB)
Collecting platformdirs>=2 (from black==25.*->-r requirements-testing.txt (line 1))
  Using cached platformdirs-4.3.8-py3-none-any.whl.metadata (12 kB)
Collecting tomli>=1.1.0 (from black==25.*->-r requirements-testing.txt (line 1))
  Using cached tomli-2.2.1-py3-none-any.whl.metadata (10 kB)
Collecting typing-extensions>=4.0.1 (from black==25.*->-r requirements-testing.txt (line 1))
  Using cached typing_extensions-4.14.1-py3-none-any.whl.metadata (3.0 kB)
Collecting exceptiongroup>=1 (from pytest==8.*->-r requirements-testing.txt (line 6))
  Using cached exceptiongroup-1.3.0-py3-none-any.whl.metadata (6.7 kB)
Collecting iniconfig>=1 (from pytest==8.*->-r requirements-testing.txt (line 6))
  Using cached iniconfig-2.1.0-py3-none-any.whl.metadata (2.7 kB)
Collecting pluggy<2,>=1.5 (from pytest==8.*->-r requirements-testing.txt (line 6))
  Using cached pluggy-1.6.0-py3-none-any.whl.metadata (4.8 kB)
Collecting pygments>=2.7.2 (from pytest==8.*->-r requirements-testing.txt (line 6))
  Using cached pygments-2.19.2-py3-none-any.whl.metadata (2.5 kB)
Collecting execnet>=2.1 (from pytest-xdist==3.*->-r requirements-testing.txt (line 8))
  Using cached execnet-2.1.1-py3-none-any.whl.metadata (2.9 kB)
Collecting readme-renderer>=35.0 (from twine==6.*->-r requirements-testing.txt (line 11))
  Using cached readme_renderer-44.0-py3-none-any.whl.metadata (2.8 kB)
Collecting requests>=2.20 (from twine==6.*->-r requirements-testing.txt (line 11))
  Using cached requests-2.32.4-py3-none-any.whl.metadata (4.9 kB)
Collecting requests-toolbelt!=0.9.0,>=0.8.0 (from twine==6.*->-r requirements-testing.txt (line 11))
  Using cached requests_toolbelt-1.0.0-py2.py3-none-any.whl.metadata (14 kB)
Collecting urllib3>=1.26.0 (from twine==6.*->-r requirements-testing.txt (line 11))
  Using cached urllib3-2.5.0-py3-none-any.whl.metadata (6.5 kB)
Collecting keyring>=15.1 (from twine==6.*->-r requirements-testing.txt (line 11))
  Using cached keyring-25.6.0-py3-none-any.whl.metadata (20 kB)
Collecting rfc3986>=1.4.0 (from twine==6.*->-r requirements-testing.txt (line 11))
  Using cached rfc3986-2.0.0-py2.py3-none-any.whl.metadata (6.6 kB)
Collecting rich>=12.0.0 (from twine==6.*->-r requirements-testing.txt (line 11))
  Using cached rich-14.0.0-py3-none-any.whl.metadata (18 kB)
Collecting id (from twine==6.*->-r requirements-testing.txt (line 11))
  Using cached id-1.5.0-py3-none-any.whl.metadata (5.2 kB)
Collecting importlib_metadata>=4.11.4 (from keyring>=15.1->twine==6.*->-r requirements-testing.txt (line 11))
  Using cached importlib_metadata-8.7.0-py3-none-any.whl.metadata (4.8 kB)
Collecting jaraco.classes (from keyring>=15.1->twine==6.*->-r requirements-testing.txt (line 11))
  Using cached jaraco.classes-3.4.0-py3-none-any.whl.metadata (2.6 kB)
Collecting jaraco.functools (from keyring>=15.1->twine==6.*->-r requirements-testing.txt (line 11))
  Using cached jaraco_functools-4.2.1-py3-none-any.whl.metadata (2.9 kB)
Collecting jaraco.context (from keyring>=15.1->twine==6.*->-r requirements-testing.txt (line 11))
  Using cached jaraco.context-6.0.1-py3-none-any.whl.metadata (4.1 kB)
Collecting nh3>=0.2.14 (from readme-renderer>=35.0->twine==6.*->-r requirements-testing.txt (line 11))
  Using cached nh3-0.2.22-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl.metadata (2.0 kB)
Collecting docutils>=0.21.2 (from readme-renderer>=35.0->twine==6.*->-r requirements-testing.txt (line 11))
  Using cached docutils-0.21.2-py3-none-any.whl.metadata (2.8 kB)
Collecting charset_normalizer<4,>=2 (from requests>=2.20->twine==6.*->-r requirements-testing.txt (line 11))
  Using cached charset_normalizer-3.4.2-cp310-cp310-macosx_10_9_universal2.whl.metadata (35 kB)
Collecting idna<4,>=2.5 (from requests>=2.20->twine==6.*->-r requirements-testing.txt (line 11))
  Using cached idna-3.10-py3-none-any.whl.metadata (10 kB)
Collecting certifi>=2017.4.17 (from requests>=2.20->twine==6.*->-r requirements-testing.txt (line 11))
  Using cached certifi-2025.7.14-py3-none-any.whl.metadata (2.4 kB)
Collecting markdown-it-py>=2.2.0 (from rich>=12.0.0->twine==6.*->-r requirements-testing.txt (line 11))
  Using cached markdown_it_py-3.0.0-py3-none-any.whl.metadata (6.9 kB)
Collecting zipp>=3.20 (from importlib_metadata>=4.11.4->keyring>=15.1->twine==6.*->-r requirements-testing.txt (line 11))
  Using cached zipp-3.23.0-py3-none-any.whl.metadata (3.6 kB)
Collecting mdurl~=0.1 (from markdown-it-py>=2.2.0->rich>=12.0.0->twine==6.*->-r requirements-testing.txt (line 11))
  Using cached mdurl-0.1.2-py3-none-any.whl.metadata (1.6 kB)
Collecting more-itertools (from jaraco.classes->keyring>=15.1->twine==6.*->-r requirements-testing.txt (line 11))
  Using cached more_itertools-10.7.0-py3-none-any.whl.metadata (37 kB)
Collecting backports.tarfile (from jaraco.context->keyring>=15.1->twine==6.*->-r requirements-testing.txt (line 11))
  Using cached backports.tarfile-1.2.0-py3-none-any.whl.metadata (2.0 kB)
Using cached black-25.1.0-cp310-cp310-macosx_11_0_arm64.whl (1.5 MB)
Using cached coverage-7.9.2-cp310-cp310-macosx_11_0_arm64.whl (212 kB)
Using cached mypy-1.17.0-cp310-cp310-macosx_11_0_arm64.whl (10.1 MB)
Using cached numpy-2.2.6-cp310-cp310-macosx_14_0_arm64.whl (5.3 MB)
Using cached pillow-11.3.0-cp310-cp310-macosx_11_0_arm64.whl (4.7 MB)
Using cached pytest-8.4.1-py3-none-any.whl (365 kB)
Using cached pytest_cov-6.2.1-py3-none-any.whl (24 kB)
Using cached pytest_xdist-3.8.0-py3-none-any.whl (46 kB)
Using cached ruff-0.12.3-py3-none-macosx_11_0_arm64.whl (10.6 MB)
Using cached types_pyyaml-6.0.12.20250516-py3-none-any.whl (20 kB)
Using cached twine-6.1.0-py3-none-any.whl (40 kB)
Using cached click-8.2.1-py3-none-any.whl (102 kB)
Using cached exceptiongroup-1.3.0-py3-none-any.whl (16 kB)
Using cached execnet-2.1.1-py3-none-any.whl (40 kB)
Using cached iniconfig-2.1.0-py3-none-any.whl (6.0 kB)
Using cached keyring-25.6.0-py3-none-any.whl (39 kB)
Using cached mypy_extensions-1.1.0-py3-none-any.whl (5.0 kB)
Using cached packaging-25.0-py3-none-any.whl (66 kB)
Using cached pathspec-0.12.1-py3-none-any.whl (31 kB)
Using cached platformdirs-4.3.8-py3-none-any.whl (18 kB)
Using cached pluggy-1.6.0-py3-none-any.whl (20 kB)
Using cached pygments-2.19.2-py3-none-any.whl (1.2 MB)
Using cached readme_renderer-44.0-py3-none-any.whl (13 kB)
Using cached requests-2.32.4-py3-none-any.whl (64 kB)
Using cached requests_toolbelt-1.0.0-py2.py3-none-any.whl (54 kB)
Using cached rfc3986-2.0.0-py2.py3-none-any.whl (31 kB)
Using cached rich-14.0.0-py3-none-any.whl (243 kB)
Using cached tomli-2.2.1-py3-none-any.whl (14 kB)
Using cached typing_extensions-4.14.1-py3-none-any.whl (43 kB)
Using cached urllib3-2.5.0-py3-none-any.whl (129 kB)
Using cached id-1.5.0-py3-none-any.whl (13 kB)
Using cached certifi-2025.7.14-py3-none-any.whl (162 kB)
Using cached charset_normalizer-3.4.2-cp310-cp310-macosx_10_9_universal2.whl (201 kB)
Using cached docutils-0.21.2-py3-none-any.whl (587 kB)
Using cached idna-3.10-py3-none-any.whl (70 kB)
Using cached importlib_metadata-8.7.0-py3-none-any.whl (27 kB)
Using cached markdown_it_py-3.0.0-py3-none-any.whl (87 kB)
Using cached nh3-0.2.22-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl (1.4 MB)
Using cached jaraco.classes-3.4.0-py3-none-any.whl (6.8 kB)
Using cached jaraco.context-6.0.1-py3-none-any.whl (6.8 kB)
Using cached jaraco_functools-4.2.1-py3-none-any.whl (10 kB)
Using cached mdurl-0.1.2-py3-none-any.whl (10.0 kB)
Using cached zipp-3.23.0-py3-none-any.whl (10 kB)
Using cached backports.tarfile-1.2.0-py3-none-any.whl (30 kB)
Using cached more_itertools-10.7.0-py3-none-any.whl (65 kB)
Installing collected packages: zipp, urllib3, typing-extensions, types-pyyaml, tomli, ruff, rfc3986, pygments, pluggy, platformdirs, pillow, pathspec, packaging, numpy, nh3, mypy-extensions, more-itertools, mdurl, iniconfig, idna, execnet, docutils, coverage, click, charset_normalizer, certifi, backports.tarfile, requests, readme-renderer, mypy, markdown-it-py, jaraco.functools, jaraco.context, jaraco.classes, importlib_metadata, exceptiongroup, black, rich, requests-toolbelt, pytest, keyring, id, twine, pytest-xdist, pytest-cov
Successfully installed backports.tarfile-1.2.0 black-25.1.0 certifi-2025.7.14 charset_normalizer-3.4.2 click-8.2.1 coverage-7.9.2 docutils-0.21.2 exceptiongroup-1.3.0 execnet-2.1.1 id-1.5.0 idna-3.10 importlib_metadata-8.7.0 iniconfig-2.1.0 jaraco.classes-3.4.0 jaraco.context-6.0.1 jaraco.functools-4.2.1 keyring-25.6.0 markdown-it-py-3.0.0 mdurl-0.1.2 more-itertools-10.7.0 mypy-1.17.0 mypy-extensions-1.1.0 nh3-0.2.22 numpy-2.2.6 packaging-25.0 pathspec-0.12.1 pillow-11.3.0 platformdirs-4.3.8 pluggy-1.6.0 pygments-2.19.2 pytest-8.4.1 pytest-cov-6.2.1 pytest-xdist-3.8.0 readme-renderer-44.0 requests-2.32.4 requests-toolbelt-1.0.0 rfc3986-2.0.0 rich-14.0.0 ruff-0.12.3 tomli-2.2.1 twine-6.1.0 types-pyyaml-6.0.12.20250516 typing-extensions-4.14.1 urllib3-2.5.0 zipp-3.23.0

[notice] A new release of pip is available: 24.3.1 -> 25.1.1
[notice] To update, run: pip install --upgrade pip
cwd: /Volumes/workplace/deadline-cloud-for-keyshot
working directory: /var/folders/k9/0q9dw35d3b12jwsq_zh3l1pc0000gr/T/tmpr562ktbu
Running cmd: [PosixPath('/Applications/InstallBuilder Enterprise 25.6.0/bin/builder'), 'build', '/Volumes/workplace/deadline-cloud-for-keyshot/installer/DeadlineCloudForKeyShotSubmitter.xml', 'osx', '--setvars', 'project.outputDirectory=/var/folders/k9/0q9dw35d3b12jwsq_zh3l1pc0000gr/T/tmpr562ktbu/out', 'project.version=0.4.3.a818613']
------------------------------
Begin Install Builder Output
------------------------------
 Building AWS Deadline Cloud for KeyShot Submitter osx
 0% ______________ 50% ______________ 100%
 #########################################

Built with an evaluation version of InstallBuilder

------------------------------
End Install Builder Output
------------------------------
```

Tests output:
```
------------------------------------------------------------------------------------------------------------
TOTAL                                                              587    298    174     20    43%
Coverage HTML written to dir build/coverage
Coverage XML written to file build/coverage/coverage.xml
Required test coverage of 18.0% reached. Total coverage: 42.97%
================================================================================================================= slowest 5 durations ==================================================================================================================
0.16s call     test/unit/test_copyright_headers.py::test_copyright_headers
0.08s call     test/unit/keyshot_submitter/test_keyshot_submitter.py::test_get_ksp_bundle_files
0.01s teardown test/unit/keyshot_submitter/test_keyshot_submitter.py::test_get_ksp_bundle_files
0.01s call     test/unit/keyshot_submitter/test_keyshot_submitter.py::test_settings_apply_submitter_settings
0.01s teardown test/unit/keyshot_adaptor/KeyShotAdaptor/test_adaptor.py::test_adaptor_prints_version_on_init
================================================================================================================== 25 passed in 3.70s ==================================================================================================================
```

### Was this change documented?
Not required, I've followed the same process as xxhash

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
