### PR TITLE
ci: move installer build/release in release workflow

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -44,20 +44,31 @@ jobs:
       with:
           tag: ${{ needs.TagRelease.outputs.tag }}
 
-  BuildAndStageInstallers:
+  BuildInstaller:
     needs: [TagRelease, PreRelease]
-    uses: aws-deadline/.github/.github/workflows/reusable_build_and_stage_installers.yml@mainline
+    uses: aws-deadline/.github/.github/workflows/reusable_build_installers.yml@mainline
     secrets: inherit
     permissions:
       id-token: write
       contents: read
     with:
-      project_name: ${{ github.event.repository.name }}
-      tag: ${{ needs.TagRelease.outputs.tag }}
+      ref_type: tags
+      ref: ${{ needs.TagRelease.outputs.tag }}
       oses: "['Windows', 'MacOS']"
+      environment: release
+      project_name: ${{ github.event.repository.name }}
+
+  Publish:
+      needs: [TagRelease, BuildInstaller]
+      uses: aws-deadline/.github/.github/workflows/reusable_publish_python.yml@mainline
+      permissions:
+        id-token: write
+      secrets: inherit
+      with:
+          tag: ${{ needs.TagRelease.outputs.tag }}
 
   IsCondaReady:
-    needs: BuildAndStageInstallers
+    needs: Publish
     runs-on: ubuntu-latest
     environment: release
     name: “Is the Conda Package available in all ProdWaves and have you ran any required manual tests?”
@@ -65,8 +76,20 @@ jobs:
       - run: |
          :
 
+  ReleaseInstaller:
+    needs: [TagRelease, IsCondaReady]
+    uses: aws-deadline/.github/.github/workflows/reusable_release_installers.yml@mainline
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      tag: ${{ needs.TagRelease.outputs.tag }}
+      oses: "['Windows', 'MacOS']"
+      project_name: ${{ github.event.repository.name }}
+
   Release:
-      needs: [TagRelease, IsCondaReady]
+      needs: [TagRelease, ReleaseInstaller]
       uses: aws-deadline/.github/.github/workflows/reusable_release.yml@mainline
       secrets: inherit
       permissions:
@@ -74,20 +97,11 @@ jobs:
         contents: write
       with:
           tag: ${{ needs.TagRelease.outputs.tag }}
-  
-  Publish:
-      needs: [TagRelease, Release]
-      uses: aws-deadline/.github/.github/workflows/reusable_publish_python.yml@mainline
-      permissions:
-        id-token: write
-      secrets: inherit
-      with:
-          tag: ${{ needs.TagRelease.outputs.tag }}
           
   # PyPI does not support reusable workflows yet
   # # See https://github.com/pypi/warehouse/issues/11096
   PublishToPyPI:
-    needs: Publish
+    needs: [TagRelease, Release]
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -96,7 +110,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.Publish.outputs.tag }}
+          ref: ${{ needs.TagRelease.outputs.tag }}
           fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
1. We want to publish to codeartifact prior to running conda testing so that it can be used to build the adaptors.
2. We want to build the installers and only release them after conda testing has been completed.

### What was the solution? (How)
1. Move the `Publish` step before the `IsCondaReady` Step.
2. Use the [reusable_build_installers.yml](https://github.com/aws-deadline/.github/blob/mainline/.github/workflows/reusable_build_installers.yml) prior to `IsCondaReady` to only build the installers. After the `IsCondaReady` step use [reusable_release_installers.yml](https://github.com/aws-deadline/.github/blob/mainline/.github/workflows/reusable_release_installers.yml) to release the installers.

### What is the impact of this change?
Re-orders the release process to better align with development needs.

### How was this change tested?

https://github.com/moorec-aws/deadline-cloud-for-blender/actions/runs/16326741245

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*