### PR TITLE
fix: update version bump action with new submitter path

### DIFF
--- a/.github/actions/bump_precommit_hook/action.yml
+++ b/.github/actions/bump_precommit_hook/action.yml
@@ -9,8 +9,5 @@ runs:
   - name: Update plugin Version
     shell: bash
     run: |
-      sed -i "s/^# VERSION.*/# VERSION ${{inputs.semver}}/" ./src/deadline/keyshot_submitter/Submit\ to\ AWS\ Deadline\ Cloud.py
-      major=$(printf ${{inputs.semver}} | cut -d '.' -f1)
-      minor=$(printf ${{inputs.semver}} | cut -d '.' -f2)
-      sed -i "s/keyshot-openjd=[0-9]*.[0-9]*.\\*/keyshot-openjd=$major.$minor.\\*/" ./src/deadline/keyshot_submitter/Submit\ to\ AWS\ Deadline\ Cloud.py
-      git add ./src/deadline/keyshot_submitter/Submit\ to\ AWS\ Deadline\ Cloud.py 
+      sed -i "s/^# VERSION.*/# VERSION ${{inputs.semver}}/" ./src/submitter.py
+      git add ./src/submitter.py 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We updated the submitter path and removed the adapter, but the version bump script was not updated.

### What was the solution? (How)
Update it.

### What is the impact of this change?
Fixes version bump in release process.

### How was this change tested?
Ran the commands locally.

### Was this change documented?
n/a

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
