### PR TITLE
fix: update submitter path for installer, add instructions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -108,5 +108,14 @@ To run the integration tests:
 
 The user guide is generated from the markdown files in `docs/user_guide` and published to GitHub pages. To view the renderd user guide locally, run `hatch run docs:serve` which will open the user guide in your browser.
 
+## Testing the installer
+
+1. Download the install builder tool from https://installbuilder.com/ (Evaluation)
+2. Run `hatch build`
+3. Run `hatch run installer:build-installer --local-dev`
+4. Installer should be built under the installer sub-folder.
+5. Double click on the built installer to run it.
+
+
 ## Relevant links
 - [Keyshot 2024 scripting documentation](https://media.keyshot.com/scripting/doc/2024.1/lux.html)

--- a/hatch.toml
+++ b/hatch.toml
@@ -51,6 +51,11 @@ deps = "pip install -r requirements-release.txt"
 bump = "semantic-release -v --strict version --no-push --no-commit --no-tag --skip-build {args}"
 version = "semantic-release -v --strict version --print {args}"
 
+[envs.installer]
+dependencies = [
+  "boto3"
+]
+
 [envs.installer.scripts]
 build-installer = "python {root}/scripts/build_installer_cli.py --installer-source-path {root}/installer/DeadlineCloudForKeyShotSubmitter.xml {args:}"
 

--- a/install_builder/deadline-cloud-for-keyshot.xml
+++ b/install_builder/deadline-cloud-for-keyshot.xml
@@ -1,6 +1,6 @@
 <component>
     <name>deadline_cloud_for_keyshot</name>
-    <description>Deadline Cloud for KeyShot 2023-2024</description>
+    <description>Deadline Cloud for KeyShot 2023-2025</description>
     <detailedDescription>KeyShot plugin for submitting jobs to AWS Deadline Cloud.</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
@@ -13,7 +13,7 @@
             <platforms>all</platforms>
             <distributionFileList>
                 <distributionFile>
-                    <origin>../src/deadline/keyshot_submitter/Submit to AWS Deadline Cloud.py</origin>
+                    <origin>../dist/Submit to AWS Deadline Cloud.py</origin>
                 </distributionFile>
             </distributionFileList>
         </folder>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The installer script needs to be updated to use new submitter script path.

### What was the solution? (How)
Update it. Also add instructions for building the installer.

### What is the impact of this change?
Fixes the installer configuration.

### How was this change tested?
I built the installer, ran it, and verified it saved the submitter in the correct place.

### Was this change documented?
Yes

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
