### PR TITLE
chore: remove boto requirement from installer env

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -51,11 +51,6 @@ deps = "pip install -r requirements-release.txt"
 bump = "semantic-release -v --strict version --no-push --no-commit --no-tag --skip-build {args}"
 version = "semantic-release -v --strict version --print {args}"
 
-[envs.installer]
-dependencies = [
-  "boto3"
-]
-
 [envs.installer.scripts]
 build-installer = "python {root}/scripts/build_installer_cli.py --installer-source-path {root}/installer/DeadlineCloudForKeyShotSubmitter.xml {args:}"
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
I added boto3 in PR https://github.com/aws-deadline/deadline-cloud-for-keyshot/pull/256 as an installer env requirement, but it's causing the installer builds to fail in the release workflow.

### What was the solution? (How)
Remove it.

### What is the impact of this change?
Should fix the installer builds.

### How was this change tested?
Ran `hatch run installer:build-installer --local-dev` locally

### Was this change documented?
n/a

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
