### PR TITLE
chore: fix installer script dependencies

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -51,11 +51,6 @@ deps = "pip install -r requirements-release.txt"
 bump = "semantic-release -v --strict version --no-push --no-commit --no-tag --skip-build {args}"
 version = "semantic-release -v --strict version --print {args}"
 
-[envs.installer]
-dependencies = [
-  "boto3"
-]
-
 [envs.installer.scripts]
 build-installer = "python {root}/scripts/build_installer_cli.py --installer-source-path {root}/installer/DeadlineCloudForKeyShotSubmitter.xml {args:}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,9 @@ classifiers = [
   "Intended Audience :: End Users/Desktop"
 ]
 
-dependencies = []
+dependencies = [
+  "boto3",
+]
 
 [project.urls]
 Homepage = "https://github.com/aws-deadline/deadline-cloud-for-keyshot"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The scripts that build the installer had their dependencies messed up. In a previous CR, I added boto3 to the env dependencies while implicitly removing it from the project dependencies which messed up the CI builds.

### What was the solution? (How)
Add boto3 as a project dependency instead of a hatch env dependency.

### What is the impact of this change?
Fixes CI builds

### How was this change tested?
Removed the hatch env dependency, ran `hatch run installer:build-installer --local-dev`, saw the missing boto3 error we're seeing in the CI build, added the boto3 dependency to pyproject.yaml, reran `hatch run installer:build-installer --local-dev` successfully.
 
### Was this change documented?
n/a

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
