### PR TITLE
chore(docs): Re-add mkdocs.yml and docs environment

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -53,3 +53,14 @@ version = "semantic-release -v --strict version --print {args}"
 
 [envs.installer.scripts]
 build-installer = "python {root}/scripts/build_installer_cli.py --installer-source-path {root}/installer/DeadlineCloudForKeyShotSubmitter.xml {args:}"
+
+[envs.docs]
+dependencies = [
+  "mkdocs>=1.5.0",
+  "mkdocs-material>=9.4.0",
+]
+
+[envs.docs.scripts]
+build = "mkdocs build"
+serve = "mkdocs serve"
+deploy = "mkdocs gh-deploy --force"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,37 @@
+site_name: AWS Deadline Cloud for KeyShot User Guide
+site_url: https://aws-deadline.github.io/deadline-cloud-for-keyshot/
+repo_url: https://github.com/aws-deadline/deadline-cloud-for-keyshot
+repo_name: aws-deadline/deadline-cloud-for-keyshot
+edit_uri: edit/mainline/docs/user_guide/
+
+theme:
+  name: material
+  palette:
+    primary: custom
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.expand
+    - content.code.copy
+extra_css:
+  - extra.css
+
+extra:
+  generator: false # Hide mkdocs-material call out
+
+copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+markdown_extensions:
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Installation: installation.md
+  - Using the Submitter: using-submitter.md
+
+plugins:
+  - search
+
+docs_dir: docs/user_guide
+site_dir: site


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to keep `mkdocs.yml` in the repository root for each integration so we can copy the page structure & order in the [main docs site](https://aws-deadline.github.io/).

### What was the solution? (How)
- Re-added `mkdocs.yml`
- Re-added the `docs` environment and command to locally serve the user guide

### What is the impact of this change?
- Changes to KeyShot's general user guide can be tested locally in isolation
- KeyShot's user guide pages can be used on the [main integration site](https://aws-deadline.github.io/)'s navigation sidebar

### How was this change tested?
Re-ran `hatch run docs:serve` to test it locally

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
