### PR TITLE
doc: add top level links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AWS Deadline Cloud for KeyShot
 
-[![license](https://img.shields.io/pypi/l/deadline-cloud-for-keyshot.svg?style=flat)](https://github.com/aws-deadline/deadline-cloud-for-keyshot/blob/mainline/LICENSE)
+### [User guide](https://aws-deadline.github.io/) | [Service documentation](https://docs.aws.amazon.com/deadline-cloud/) | [Deadline Cloud on GitHub](https://github.com/aws-deadline/) 
 
 AWS Deadline Cloud for KeyShot is a Python plugin that allows users to create [AWS Deadline Cloud][deadline-cloud] jobs from within KeyShot.
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to add a link to the user guide from the README.

### What was the solution? (How)
Add it. Also add links to the service docs and GitHub org page which might also be useful depending on what the user is looking for. Also dropping the license badge because the license is noted elsewhere and it's not important enough to be the first thing on the README.

### What is the impact of this change?
Easier to find docs.

### How was this change tested?
https://github.com/crowecawcaw/deadline-cloud-for-keyshot/?tab=readme-ov-file#user-guide--service-documentation--deadline-cloud-on-github

### Was this change documented?
Yes

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
