### PR TITLE
ci: add Security Scan stub (zizmor via reusable org workflow)

### DIFF
--- a/.github/actions/bump_precommit_hook/action.yml
+++ b/.github/actions/bump_precommit_hook/action.yml
@@ -8,6 +8,9 @@ runs:
   steps:
   - name: Update plugin Version
     shell: bash
+    env:
+      # Pass input via env, not inline ${{ }}, to avoid template injection.
+      SEMVER: ${{ inputs.semver }}
     run: |
-      sed -i "s/^# VERSION.*/# VERSION ${{inputs.semver}}/" ./src/submitter.py
+      sed -i "s/^# VERSION.*/# VERSION $SEMVER/" ./src/submitter.py
       git add ./src/submitter.py 

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -7,11 +7,12 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    # canonical dependabot auto-approve pattern; the job only has pull-requests: write and runs Dependabot's own metadata action
+    if: ${{ github.actor == 'dependabot[bot]' }} # zizmor: ignore[bot-conditions]
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR

--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -11,7 +11,7 @@
 # workflow_run identifiers and the role-ARN secret.
 name: Claude PR Review
 
-on:
+on: # zizmor: ignore[dangerous-triggers] -- workflow_run is intentional and safe here; see the header comment above (runs from default branch, fork PRs cannot alter behavior/secrets)
   workflow_run:
     workflows: ["Claude PR Review (collect)"]
     types:

--- a/.github/workflows/on_opened_pr.yml
+++ b/.github/workflows/on_opened_pr.yml
@@ -1,6 +1,9 @@
 name: On Opened PR
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
+  # workflow_run is intentional: it runs from the default branch with this
+  # repo's context (never a fork's copy), and only consumes the PR artifact via
+  # the reusable extract-PR-details workflow. A fork PR cannot alter behavior.
   workflow_run:
     workflows: ["Record PR"]
     types:

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -1,0 +1,21 @@
+name: "Security Scan"
+
+on:
+  push:
+    branches: [ "mainline", "feature_*", "patch_*" ]
+  pull_request:
+    branches: [ "mainline", "feature_*", "patch_*" ]
+  schedule:
+    - cron: '0 8 * * MON'
+
+jobs:
+  Scan:
+    name: Scan
+    # Central, extensible security-scan workflow (currently zizmor). New checks
+    # added there apply here automatically — no change needed to this stub.
+    uses: aws-deadline/.github/.github/workflows/reusable_security_scan.yml@mainline
+    permissions:
+      # The reusable workflow checks out this repo and fetches the central
+      # zizmor config, and reports findings to the run log / PR annotations
+      # (not the Security tab), so it only needs read access.
+      contents: read


### PR DESCRIPTION
## What

Adds a thin **Security Scan** stub at `.github/workflows/security_scan.yml` that calls the central reusable workflow `aws-deadline/.github/.github/workflows/reusable_security_scan.yml@mainline`. That reusable workflow runs [zizmor](https://docs.zizmor.sh/) with the org-wide central config and gates PRs on **high**-severity findings. New checks added centrally apply here automatically — no per-repo change needed.

Replicates what was done in `aws-deadline/deadline-cloud` (merged PR #1256).

## Pre-req fixes (so the gate is green)

Because the gate fails on high findings, this PR first fixes all existing high-severity zizmor findings in the repo's workflows:

**Fixed:**
- `template-injection` (1) — `.github/actions/bump_precommit_hook/action.yml`: moved `${{ inputs.semver }}` out of the `run:` block into an `env:` var referenced as `$SEMVER`.
- `unpinned-uses` (1) — `auto_approve.yml`: pinned `dependabot/fetch-metadata` to a full commit SHA (`v3.1.0`).

**Intentional suppressions (`# zizmor: ignore`):**
- `bot-conditions` (1) — `auto_approve.yml`: canonical Dependabot auto-approve actor check; the job only holds `pull-requests: write` and runs Dependabot's own metadata action.
- `dangerous-triggers` (2) — `claude_pr_review.yml`, `on_opened_pr.yml`: `workflow_run` is intentional; these run from the default branch with this repo's context (never a fork's copy), so a fork PR cannot alter behavior or access secrets.

After the fixes, `zizmor --min-severity high` reports **0 findings**.

Draft until CI (Security Scan) is confirmed green.